### PR TITLE
Rename `typeLocation` to `parameter` to better reflect its usage

### DIFF
--- a/include/smeagle/corpora.h
+++ b/include/smeagle/corpora.h
@@ -19,7 +19,7 @@ namespace smeagle {
    */
   class Corpus {
     std::string library;
-    std::vector <parameter> typelocs;
+    std::vector <parameter> params;
 
   public:
     /**

--- a/include/smeagle/corpora.h
+++ b/include/smeagle/corpora.h
@@ -10,7 +10,7 @@
 
 #include "Symtab.h"
 
-#include "smeagle/TypeLocation.h"
+#include "smeagle/parameter.h"
 
 namespace smeagle {
 
@@ -19,7 +19,7 @@ namespace smeagle {
    */
   class Corpus {
     std::string library;
-    std::vector <TypeLocation> typelocs;
+    std::vector <parameter> typelocs;
 
   public:
     /**

--- a/include/smeagle/parameter.h
+++ b/include/smeagle/parameter.h
@@ -5,13 +5,22 @@
 
 #pragma once
 
-// A type location has a name, type, export/import, and location
-struct TypeLocation {
+#include <string>
+
+namespace smeagle {
+
+/***
+ * \brief Representation of a parameter in an interface
+ *
+ * A parameter can be a formal parameter of a function definition,
+ * an actual parameter at a callsite, or a return value from a function.
+ *
+ */
+struct parameter {
 	std::string name;
-	std::string parent;
 	std::string type;
-	std::string reg;
 	std::string exportOrImport;
-	std::string locoffset;
 	std::string location;
 };
+
+}

--- a/source/corpora.cpp
+++ b/source/corpora.cpp
@@ -22,6 +22,7 @@ Corpus::Corpus(std::string _library) : library(std::move(_library)) {};
 void Corpus::toAsp() {
 
     std::cout << "corpus(" << library << ")," << std::endl;
+
     for (auto &typeloc : typelocs) {
         std::cout << "abi_typelocation(" << library
                   << ", " << p.name << ", " << p.type << ", \""
@@ -33,6 +34,7 @@ void Corpus::toAsp() {
 void Corpus::toYaml() {
 
     std::cout << "library: \"" << library << "\"\nlocations: " << std::endl;
+
     for (auto &typeloc : typelocs) {
         std::cout << " - library: " << library
                   << "\n   name: " << p.name
@@ -47,20 +49,20 @@ void Corpus::toYaml() {
 void Corpus::toJson() {
 
     std::cout << "{ \"library\": \"" << library << "\", \"locations\": [" << std::endl;
-    for (auto &typeloc : typelocs) {
+    for (auto &p : params) {
 
         // Check if we are at the last entry (no comma) or not
         std::string endcomma;
-        if (&typeloc == &typelocs.back())
+        if (&p == &params.back())
             endcomma = "";
         else {
             endcomma = ",";
         }
-        std::cout << "{\"library\": \"" << library
-				  << "\", \"name\": \"" << p.name
-				  << "\", \"type\": \"" << p.type
-				  << "\", \"location\": \"" << p.location
-				  << "\"}"
+
+        std::cout << "{\"library\": \"" << library << "\", \"parent\": \""
+                  << p.parent << "\", \"name\": \"" << p.name << "\", \"type\": \""
+                  << p.type << "\", \"location\": \"" << p.location << "\", "
+                  << "\"register\": \"" << p.reg << "\"}"
                   << endcomma << std::endl;
     }
     std::cout << "]}" << std::endl;
@@ -71,7 +73,7 @@ void Corpus::toJson() {
 void Corpus::parseFunctionABILocation(Dyninst::SymtabAPI::Symbol *symbol, Dyninst::Architecture arch) {
     switch (arch) {
       case Dyninst::Architecture::Arch_x86_64:
-        typelocs = std::move(x86_64::parse_parameters(symbol));
+        params = std::move(x86_64::parse_parameters(symbol));
         break;
       case Dyninst::Architecture::Arch_aarch64:
         break;

--- a/source/corpora.cpp
+++ b/source/corpora.cpp
@@ -23,7 +23,7 @@ void Corpus::toAsp() {
 
     std::cout << "corpus(" << library << ")," << std::endl;
 
-    for (auto &typeloc : typelocs) {
+    for (auto &p : params) {
         std::cout << "abi_typelocation(" << library
                   << ", " << p.name << ", " << p.type << ", \""
                   << p.location << "\")" << std::endl;
@@ -35,7 +35,7 @@ void Corpus::toYaml() {
 
     std::cout << "library: \"" << library << "\"\nlocations: " << std::endl;
 
-    for (auto &typeloc : typelocs) {
+    for (auto &p : params) {
         std::cout << " - library: " << library
                   << "\n   name: " << p.name
 				  << "\n   type: " << p.type
@@ -59,10 +59,11 @@ void Corpus::toJson() {
             endcomma = ",";
         }
 
-        std::cout << "{\"library\": \"" << library << "\", \"parent\": \""
-                  << p.parent << "\", \"name\": \"" << p.name << "\", \"type\": \""
-                  << p.type << "\", \"location\": \"" << p.location << "\", "
-                  << "\"register\": \"" << p.reg << "\"}"
+        std::cout << "{\"library\": \"" << library
+				  << "\", \"name\": \"" << p.name
+				  << "\", \"type\": \"" << p.type
+				  << "\", \"location\": \"" << p.location
+				  << "\"}"
                   << endcomma << std::endl;
     }
     std::cout << "]}" << std::endl;

--- a/source/corpora.cpp
+++ b/source/corpora.cpp
@@ -23,10 +23,9 @@ void Corpus::toAsp() {
 
     std::cout << "corpus(" << library << ")," << std::endl;
     for (auto &typeloc : typelocs) {
-
-        std::cout << "abi_typelocation(" << library << ", " << typeloc.parent
-                  << ", " << typeloc.name << ", " << typeloc.type << ", \""
-                  << typeloc.location << ", " << typeloc.reg << "\")" << std::endl;
+        std::cout << "abi_typelocation(" << library
+                  << ", " << p.name << ", " << p.type << ", \""
+                  << p.location << "\")" << std::endl;
     }
 }
 
@@ -35,11 +34,11 @@ void Corpus::toYaml() {
 
     std::cout << "library: \"" << library << "\"\nlocations: " << std::endl;
     for (auto &typeloc : typelocs) {
-
-        std::cout << " - library: " << library << "\n   parent: " << typeloc.parent
-                  << "\n   name: " << typeloc.name << "\n   type: " << typeloc.type
-                  << "\n   location: " <<  typeloc.location << "\n   register: "
-                  << typeloc.reg << "\n" << std::endl;
+        std::cout << " - library: " << library
+                  << "\n   name: " << p.name
+				  << "\n   type: " << p.type
+                  << "\n   location: " <<  p.location
+				  << "\n" << std::endl;
     }
 }
 
@@ -57,10 +56,11 @@ void Corpus::toJson() {
         else {
             endcomma = ",";
         }
-        std::cout << "{\"library\": \"" << library << "\", \"parent\": \""
-                  << typeloc.parent << "\", \"name\": \"" << typeloc.name << "\", \"type\": \""
-                  << typeloc.type << "\", \"location\": \"" << typeloc.location << "\", "
-                  << "\"register\": \"" << typeloc.reg << "\"}"
+        std::cout << "{\"library\": \"" << library
+				  << "\", \"name\": \"" << p.name
+				  << "\", \"type\": \"" << p.type
+				  << "\", \"location\": \"" << p.location
+				  << "\"}"
                   << endcomma << std::endl;
     }
     std::cout << "]}" << std::endl;

--- a/source/detail/parser/x86_64.cpp
+++ b/source/detail/parser/x86_64.cpp
@@ -308,14 +308,14 @@ namespace smeagle::x86_64 {
 	      // std::string locoffset = getParamLocationOffset(param);
 
 	      // Create a new typelocation to parse later
-	      parameter typeloc;
-	      typeloc.name = paramName;
-	      typeloc.type = paramType->getName();
+	      parameter p;
+	      p.name = paramName;
+	      p.type = paramType->getName();
 
 	      // TODO how to determine if export/import?
-	      typeloc.exportOrImport = "export";
-	      typeloc.location = "framebase+" + std::to_string(framebase);
-	      typelocs.push_back(typeloc);
+	      p.exportOrImport = "export";
+	      p.location = "framebase+" + std::to_string(framebase);
+	      typelocs.push_back(p);
 	      order += 1;
 
 	      // Update the framebase for the next parameter based on the type

--- a/source/detail/parser/x86_64.cpp
+++ b/source/detail/parser/x86_64.cpp
@@ -9,7 +9,7 @@
 #include <utility>
 #include <vector>
 
-#include "smeagle/TypeLocation.h"
+#include "smeagle/parameter.h"
 
 #include "Function.h"
 #include "Symtab.h"
@@ -273,7 +273,7 @@ namespace smeagle::x86_64 {
     return regString;
   }
 
-  std::vector<TypeLocation> parse_parameters(st::Symbol *symbol) {
+  std::vector<parameter> parse_parameters(st::Symbol *symbol) {
 	  // Get the name and type of the symbol
 	  std::string sname = symbol->getMangledName();
 	  std::string stype = getStringSymbolType(symbol);
@@ -284,7 +284,7 @@ namespace smeagle::x86_64 {
 	  // The function name looks equivalent to the symbol name
 	  std::string fname = func->getName();
 
-	  std::vector<TypeLocation> typelocs;
+	  std::vector<parameter> typelocs;
 
 	  // Get parameters with types and names
 	  if (func->getParams(params)) {
@@ -308,14 +308,12 @@ namespace smeagle::x86_64 {
 	      // std::string locoffset = getParamLocationOffset(param);
 
 	      // Create a new typelocation to parse later
-	      TypeLocation typeloc;
+	      parameter typeloc;
 	      typeloc.name = paramName;
-	      typeloc.parent = fname;
 	      typeloc.type = paramType->getName();
 
 	      // TODO how to determine if export/import?
 	      typeloc.exportOrImport = "export";
-	//      typeloc.reg = loc;
 	      typeloc.location = "framebase+" + std::to_string(framebase);
 	      typelocs.push_back(typeloc);
 	      order += 1;

--- a/source/detail/parser/x86_64.hpp
+++ b/source/detail/parser/x86_64.hpp
@@ -9,9 +9,9 @@
 
 #include "Symtab.h"
 
-#include "smeagle/TypeLocation.h"
+#include "smeagle/parameter.h"
 
 namespace smeagle::x86_64 {
 
-  std::vector<TypeLocation> parse_parameters(Dyninst::SymtabAPI::Symbol *symbol);
+  std::vector<parameter> parse_parameters(Dyninst::SymtabAPI::Symbol *symbol);
 }  // namespace smeagle::x86_64


### PR DESCRIPTION
This just reflects our movement away from information derived from location lists to more agnostic representations of ABIs.