### PR TITLE
adding directionality to parameters.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ghcr.io/autamus/dyninst
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
     apt-get install -y wget g++ libssl-dev libtbb-dev python3-dev build-essential \
-    python3-jinja2 python3-pygments ghostscript doxygen python3-yaml python3-pip clang-format
+    python3-jinja2 python3-pygments ghostscript doxygen python3-yaml python3-pip clang-format git
 RUN cd /tmp && \
     wget https://github.com/Kitware/CMake/releases/download/v3.20.2/cmake-3.20.2.tar.gz && \
     tar -xzvf cmake-3.20.2.tar.gz && \

--- a/include/smeagle/parameter.h
+++ b/include/smeagle/parameter.h
@@ -19,7 +19,7 @@ namespace smeagle {
   struct parameter {
     std::string name;
     std::string type;
-    std::string exportOrImport;
+    std::string direction;
     std::string location;
   };
 

--- a/source/corpora.cpp
+++ b/source/corpora.cpp
@@ -24,7 +24,7 @@ void Corpus::toAsp() {
 
   for (auto &p : params) {
     std::cout << "abi_typelocation(" << library << ", " << p.name << ", " << p.type << ", \""
-              << p.location << "\")" << std::endl;
+              << p.location << "\", " << p.direction << ")" << std::endl;
   }
 }
 
@@ -34,7 +34,7 @@ void Corpus::toYaml() {
 
   for (auto &p : params) {
     std::cout << " - library: " << library << "\n   name: " << p.name << "\n   type: " << p.type
-              << "\n   location: " << p.location << "\n"
+              << "\n   location: " << p.location << "\n   direction: " << p.direction << "\n"
               << std::endl;
   }
 }
@@ -52,7 +52,8 @@ void Corpus::toJson() {
     }
 
     std::cout << "{\"library\": \"" << library << "\", \"name\": \"" << p.name << "\", \"type\": \""
-              << p.type << "\", \"location\": \"" << p.location << "\"}" << endcomma << std::endl;
+              << p.type << "\", \"location\": \"" << p.location << "\", \"direction\": \""
+              << p.direction << "\"}" << endcomma << std::endl;
   }
   std::cout << "]}" << std::endl;
 }

--- a/source/detail/parser/x86_64.cpp
+++ b/source/detail/parser/x86_64.cpp
@@ -129,13 +129,15 @@ namespace smeagle::x86_64 {
     return result.str();
   }
 
+  // return true if data class is reference or pointer
+  bool is_indirect(st::dataClass dc) { return dc == st::dataPointer || dc == st::dataReference; }
+
   // Get directionality from argument type
   std::string getDirectionalityFromType(st::Type *paramType) {
     auto dataType = paramType->getDataClass();
-    std::string dataTypeStr = st::dataClass2Str(dataType);
 
     // If it's a pointer, we need to know what it's pointing to!
-    if (dataTypeStr == "pointer" || dataTypeStr == "reference") {
+    if (is_indirect(dataType)) {
       auto pointerType = paramType->getPointerType();
 
       // if typo is pointer but type is primitive: imported

--- a/source/detail/parser/x86_64.cpp
+++ b/source/detail/parser/x86_64.cpp
@@ -134,10 +134,12 @@ namespace smeagle::x86_64 {
 
   // Get directionality from argument type
   std::string getDirectionalityFromType(st::Type *paramType) {
-    auto dataType = paramType->getDataClass();
+    auto dataClass = paramType->getDataClass();
+
+    // TODO add more detailed cases here for export
 
     // If it's a pointer, we need to know what it's pointing to!
-    if (is_indirect(dataType)) {
+    if (is_indirect(dataClass)) {
       auto pointerType = paramType->getPointerType();
 
       // if typo is pointer but type is primitive: imported
@@ -151,7 +153,7 @@ namespace smeagle::x86_64 {
     }
 
     // Do we default to export?
-    return "export";
+    return "import";
   }
 
   // Get register class given the argument type


### PR DESCRIPTION
This can currently be import/export but I expect this will change. I'm also wondering if it's the case that null/undefined is a primitive type, how will that show up as a type string?

Signed-off-by: vsoch <vsoch@users.noreply.github.com>