### PR TITLE
moving print

### DIFF
--- a/include/smeagle/smeagle.h
+++ b/include/smeagle/smeagle.h
@@ -8,6 +8,7 @@
 #include <string>
 
 #include "Symtab.h"
+#include "corpora.h"
 
 using namespace Dyninst;
 using namespace SymtabAPI;
@@ -35,7 +36,7 @@ namespace smeagle {
      * @param fmt the format to print to the screen
      * @return a string containing the output
      */
-    int parse(FormatCode fmt = FormatCode::Yaml);
+    smeagle::Corpus parse();
   };
 
 }  // namespace smeagle

--- a/source/smeagle.cpp
+++ b/source/smeagle.cpp
@@ -21,7 +21,7 @@ using namespace smeagle;
 Smeagle::Smeagle(std::string _library) : library(std::move(_library)) {}
 
 // Parse the library with smeagle
-int Smeagle::parse(FormatCode fmt) {
+smeagle::Corpus Smeagle::parse() {
   // We are going to read functions and symbols
   Symtab *obj = NULL;
   std::vector<Symbol *> symbols;
@@ -29,21 +29,18 @@ int Smeagle::parse(FormatCode fmt) {
 
   // Read the library into the Symtab object, cut out early if there's error
   if (not Symtab::openFile(obj, library)) {
-    std::cout << "There was a problem reading " << library << "\n";
-    return 1;
+    throw "There was a problem reading the library..";
   }
 
   // Get all functions in the library
   if (not obj->getAllFunctions(funcs)) {
-    std::cout << "There was a problem getting functions from " << library << "\n";
-    return 1;
+    throw "There was a problem getting functions from the library.";
   }
 
   // Get all functions in the library
   // Note: looping through this doesn't seem to work
   if (not obj->getAllSymbols(symbols)) {
-    std::cout << "There was a problem getting symbols from " << library << "\n";
-    return 1;
+    throw "There was a problem getting symbols from the library..";
   }
 
   // Create a corpus
@@ -64,19 +61,6 @@ int Smeagle::parse(FormatCode fmt) {
     }
   }
 
-  // Generate output (for now, all are asp).
-  switch (fmt) {
-    default:
-    case FormatCode::Json:
-      corpus.toJson();
-      break;
-    case FormatCode::Asp:
-      corpus.toAsp();
-      break;
-    case FormatCode::Yaml:
-      corpus.toYaml();
-      break;
-  }
-
-  return 0;
+  // Return the corpus for further processing
+  return corpus;
 }

--- a/source/smeagle.cpp
+++ b/source/smeagle.cpp
@@ -10,6 +10,7 @@
 
 #include <iostream>
 #include <regex>
+#include <stdexcept>
 
 #include "Function.h"
 #include "Symtab.h"
@@ -29,18 +30,18 @@ smeagle::Corpus Smeagle::parse() {
 
   // Read the library into the Symtab object, cut out early if there's error
   if (not Symtab::openFile(obj, library)) {
-    throw "There was a problem reading the library..";
+    throw std::runtime_error{"There was a problem reading from '" + library + "'"};
   }
 
   // Get all functions in the library
   if (not obj->getAllFunctions(funcs)) {
-    throw "There was a problem getting functions from the library.";
+    throw std::runtime_error{"There was a problem getting functions from '" + library + "'"};
   }
 
   // Get all functions in the library
   // Note: looping through this doesn't seem to work
   if (not obj->getAllSymbols(symbols)) {
-    throw "There was a problem getting symbols from the library..";
+    throw std::runtime_error{"There was a problem getting symbols from '" + library + "'"};
   }
 
   // Create a corpus

--- a/standalone/source/main.cpp
+++ b/standalone/source/main.cpp
@@ -3,6 +3,7 @@
 //
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+#include <smeagle/corpora.h>
 #include <smeagle/smeagle.h>
 #include <smeagle/version.h>
 
@@ -57,7 +58,21 @@ auto main(int argc, char** argv) -> int {
   }
 
   smeagle::Smeagle smeagle(library);
-  smeagle.parse(format->second);
+  smeagle::Corpus corpus = smeagle.parse();
+
+  // Generate output (json, asp, or yaml)
+  switch (format->second) {
+    default:
+    case smeagle::FormatCode::Json:
+      corpus.toJson();
+      break;
+    case smeagle::FormatCode::Asp:
+      corpus.toAsp();
+      break;
+    case smeagle::FormatCode::Yaml:
+      corpus.toYaml();
+      break;
+  }
 
   return 0;
 }


### PR DESCRIPTION
We need to be able to return just a corpus to write tests, so this moves the print into the standalone function to allow for that.

Signed-off-by: vsoch <vsoch@users.noreply.github.com>