### PR TITLE
Adding back register string calculation

### DIFF
--- a/include/smeagle/corpora.h
+++ b/include/smeagle/corpora.h
@@ -30,7 +30,7 @@ namespace smeagle {
      * @brief Parse a function symbol into parameters, types, locations
      * @param symbol the symbol that is determined to be a function
      */
-    void parseFunctionABILocation(Dyninst::SymtabAPI::Symbol *, Dyninst::Architecture);
+    void parseFunctionABILocation(Dyninst::SymtabAPI::Symbol*, Dyninst::Architecture);
 
     /**
      * @brief Dump a corpus to asp
@@ -47,9 +47,7 @@ namespace smeagle {
      */
     void toYaml();
 
-    std::vector<abi_description> const& getFunctions() const {
-    	return functions;
-    }
+    std::vector<abi_description> const& getFunctions() const { return functions; }
   };
 
 }  // namespace smeagle

--- a/source/detail/parser/x86_64.cpp
+++ b/source/detail/parser/x86_64.cpp
@@ -104,36 +104,12 @@ namespace smeagle::x86_64 {
 
   static bool is_typedef(st::dataClass dc) { return dc == st::dataTypedef; }
 
+  // Get the next greater multiple of 8
+  int nextMultipleEight(int number) { return ((number + 7) & (-8)); }
+
   // Get a framebase for a variable based on stack location and type
   int updateFramebaseFromType(st::Type *paramType, int framebase) {
-    // sizeof 16 with alignment bytes 16
-    std::regex check16("(__int128|long double|__float128|__m128)");
-
-    // sizeof 8 with alignment bytes 8
-    std::regex check8("(long|[*]|double|m_64|__int128)");
-
-    // sizeof 1 with alginment bytes 1
-    std::regex check1("(char|bool)");
-
-    // sizeof 2 with alignment bytes 2
-    std::regex check2("short");
-
-    // sizeof 4 with alignment bytes 4
-    std::regex check4("(int|enum|float)");
-
-    std::string paramTypeString = paramType->getName();
-
-    if (std::regex_search(paramTypeString, check16)) {
-      framebase += 16;
-    } else if (std::regex_search(paramTypeString, check8)) {
-      framebase += 8;
-    } else if (std::regex_search(paramTypeString, check1)) {
-      framebase += 1;
-    } else if (std::regex_search(paramTypeString, check2)) {
-      framebase += 2;
-    } else if (std::regex_search(paramTypeString, check4)) {
-      framebase += 4;
-    }
+    framebase += nextMultipleEight(paramType->getSize());
     return framebase;
   }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -29,11 +29,7 @@ else()
 endif()
 
 # ---- Create binary ----
-add_executable(SmeagleTests
-	source/main.cpp
-	source/smeagle.cpp
-	source/directionality.cpp
-)
+add_executable(SmeagleTests source/main.cpp source/smeagle.cpp source/directionality.cpp)
 target_link_libraries(SmeagleTests doctest::doctest Smeagle::Smeagle symtabAPI)
 set_target_properties(SmeagleTests PROPERTIES CXX_STANDARD 17)
 

--- a/test/source/directionality.cpp
+++ b/test/source/directionality.cpp
@@ -4,31 +4,24 @@
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 #include <doctest/doctest.h>
+
 #include "smeagle/smeagle.h"
 
-
 TEST_CASE("Parameter Directionality") {
-
   auto corpus = smeagle::Smeagle("libdirectionality.so").parse();
 
   auto funcs = corpus.getFunctions();
 
   // We only want the "foo" function
-  funcs.erase(
-	 std::remove_if(
-		 funcs.begin(), funcs.end(),
-		 [](smeagle::abi_description const& d){
-	  	  	  return d.function_name.find("foo") == std::string::npos;
-  	  	 }
-	 ),
-	 funcs.end()
-  );
+  funcs.erase(std::remove_if(funcs.begin(), funcs.end(),
+                             [](smeagle::abi_description const& d) {
+                               return d.function_name.find("foo") == std::string::npos;
+                             }),
+              funcs.end());
 
   REQUIRE(funcs.size() == 1);
 
   auto const& parameters = funcs[0].parameters;
 
-  SUBCASE("A simple int") {
-	  CHECK(parameters[0].direction == "import");
-  }
+  SUBCASE("A simple int") { CHECK(parameters[0].direction == "import"); }
 }

--- a/test/source/libs/directionality.cpp
+++ b/test/source/libs/directionality.cpp
@@ -1,3 +1,4 @@
-// A function to test parsing the directionality (i.e., import/export) status of various parameter types
+// A function to test parsing the directionality (i.e., import/export) status of various parameter
+// types
 
 void foo(int x) {}


### PR DESCRIPTION
This PR will restore the function to calculate (or get strings for) the register classes, and change them to be a `std::pair` instead of a vector.

I ran make fmt on the files so there are some previously done changes that are just getting formatting The outputs now include registers:

```yaml
  - function:
...
      parameters:
        - name: threadId
          type: Tcl_ThreadId
          location: framebase+8
          register: %rdi|%rdi
          direction: unknown
        - name: state
          type: int *
          location: framebase+8
          register: %rsi
          direction: import
```

```asp
abi_typelocation(Tcl_UtfCharComplete, src, const char *, "framebase+8", "%rdi", import)
abi_typelocation(Tcl_UtfCharComplete, length, int, "framebase+16", "%rsi", import)
abi_typelocation(Tcl_AddObjErrorInfo, interp, Tcl_Interp *, "framebase+8", "%rdi|%rdi", unknown)
abi_typelocation(Tcl_AddObjErrorInfo, message, const char *, "framebase+16", "%rsi", import)
abi_typelocation(Tcl_AddObjErrorInfo, length, int, "framebase+24", "%rdx", import)
```

```
   {
    "function": {
      "name": "TclVarErrMsg,
      "parameters": [
     {"name":"interp", "type":"Tcl_Interp *", "location":"framebase+8", "register":"%rdi|%rdi", "direction":"unknown"},
     {"name":"part1", "type":"const char *", "location":"framebase+16", "register":"%rsi", "direction":"import"},
     {"name":"part2", "type":"const char *", "location":"framebase+24", "register":"%rdx", "direction":"import"},
     {"name":"operation", "type":"const char *", "location":"framebase+32", "register":"%rcx", "direction":"import"},
     {"name":"reason", "type":"const char *", "location":"framebase+40", "register":"%r8", "direction":"import"}
    ]
   }
```

Signed-off-by: vsoch <vsoch@users.noreply.github.com>