### PR TITLE
Remove unused variable in parse_parameters

### DIFF
--- a/source/detail/parser/x86_64.cpp
+++ b/source/detail/parser/x86_64.cpp
@@ -339,7 +339,6 @@ namespace smeagle::x86_64 {
   std::vector<parameter> parse_parameters(st::Symbol *symbol) {
     // Get the name and type of the symbol
     std::string sname = symbol->getMangledName();
-    std::string stype = getStringSymbolType(symbol);
 
     st::Function *func = symbol->getFunction();
     std::vector<st::localVar *> params;


### PR DESCRIPTION
I'm not sure why the compiler didn't pick this up. We are using the warnings that would detect this.