### PR TITLE
Adding --has-exceptions to smeagle

### DIFF
--- a/include/smeagle/smeagle.h
+++ b/include/smeagle/smeagle.h
@@ -37,6 +37,9 @@ namespace smeagle {
      * @return a string containing the output
      */
     smeagle::Corpus parse();
+
+    // Determine if the library has exceptions with smeagle
+    bool has_exceptions();
   };
 
 }  // namespace smeagle

--- a/source/smeagle.cpp
+++ b/source/smeagle.cpp
@@ -31,9 +31,6 @@ bool Smeagle::has_exceptions() {
     throw std::runtime_error{"There was a problem reading from '" + library + "'"};
   }
 
-  // Create a corpus
-  Corpus corpus(library);
-
   // Parse exceptions
   obj->getAllExceptions(exceptions);
   std::cout << library << ": " << exceptions.size() << " exceptions." << std::endl;

--- a/source/smeagle.cpp
+++ b/source/smeagle.cpp
@@ -21,6 +21,28 @@ using namespace smeagle;
 
 Smeagle::Smeagle(std::string _library) : library(std::move(_library)) {}
 
+// Determine if the library has exceptions with smeagle
+bool Smeagle::has_exceptions() {
+  Symtab *obj = NULL;
+  std::vector<ExceptionBlock *> exceptions;
+
+  // Read the library into the Symtab object, cut out early if there's error
+  if (not Symtab::openFile(obj, library)) {
+    throw std::runtime_error{"There was a problem reading from '" + library + "'"};
+  }
+
+  // Create a corpus
+  Corpus corpus(library);
+
+  // Parse exceptions
+  obj->getAllExceptions(exceptions);
+  std::cout << library << ": " << exceptions.size() << " exceptions." << std::endl;
+  if (exceptions.size() == 0) {
+    return false;
+  }
+  return true;
+}
+
 // Parse the library with smeagle
 smeagle::Corpus Smeagle::parse() {
   // We are going to read functions and symbols

--- a/standalone/source/main.cpp
+++ b/standalone/source/main.cpp
@@ -29,8 +29,10 @@ auto main(int argc, char** argv) -> int {
     ("h,help", "Show help")
     ("v,version", "Print the current version number")
     ("l,library", "Library to inspect", cxxopts::value(library))
+    ("has-exceptions", "Show if a library has exceptions")
     ("f,fmt", "Format to output in", cxxopts::value(fmt)->default_value("yaml"))
   ;
+
   // clang-format on
 
   auto result = options.parse(argc, argv);
@@ -58,6 +60,11 @@ auto main(int argc, char** argv) -> int {
   }
 
   smeagle::Smeagle smeagle(library);
+
+  if (result["has-exceptions"].as<bool>()) {
+    smeagle.has_exceptions();
+    return 0;
+  }
   smeagle::Corpus corpus = smeagle.parse();
 
   // Generate output (json, asp, or yaml)


### PR DESCRIPTION
@hainest I thought it might be useful to add a flag to smeagle so that it would just output if a binary has exceptions or not, using the logic we figured out for Dyninst last week. With this if we had a huge collection of binaries somewhere we could run over the collection and determine which have exceptions defined.

```bash
# ./build/standalone/Smeagle -l libtcl8.6.so --has-exceptions
libtcl8.6.so: 0 exceptions.
```