### PR TITLE
Use Dyninst for x86_64 classification of types

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -10,7 +10,7 @@ env:
 jobs:
   build:
     name: Build and publish documentation
-    container: ghcr.io/autamus/dyninst
+    container: ghcr.io/autamus/dyninst:master
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -9,7 +9,7 @@ env:
 
 jobs:
   build:
-    container: ghcr.io/autamus/dyninst
+    container: ghcr.io/autamus/dyninst:master
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   build:
-    container: ghcr.io/autamus/dyninst
+    container: ghcr.io/autamus/dyninst:master
     runs-on: ubuntu-latest
     steps:
 

--- a/source/parser/x86_64/allocators.hpp
+++ b/source/parser/x86_64/allocators.hpp
@@ -5,12 +5,13 @@
 
 #pragma once
 
+#include <optional>
 #include <stack>
-#include <vector>
+#include <stdexcept>
+#include <string>
 
-#include "Symtab.h"
+#include "Type.h"
 #include "register_class.hpp"
-#include "smeagle/parameter.h"
 
 namespace smeagle::x86_64 {
 

--- a/source/parser/x86_64/allocators.hpp
+++ b/source/parser/x86_64/allocators.hpp
@@ -95,13 +95,9 @@ namespace smeagle::x86_64 {
          */
       }
 
-      if (lo == RegisterClass::X87) {
-        // goes on the stack
-        return fallocator.nextFramebaseFromType(paramType);
-      }
-
-      if (lo == RegisterClass::COMPLEX_X87) {
-        // goes on the stack
+      // If the class is X87, X87UP or COMPLEX_X87, it is passed in memory
+      if (lo == RegisterClass::X87 || lo == RegisterClass::COMPLEX_X87
+          || hi == RegisterClass::X87UP) {
         return fallocator.nextFramebaseFromType(paramType);
       }
 

--- a/source/parser/x86_64/allocators.hpp
+++ b/source/parser/x86_64/allocators.hpp
@@ -54,35 +54,59 @@ namespace smeagle::x86_64 {
     }
 
     // Given two registers, return one combined string
-    std::string getRegistersString(std::pair<RegisterClass, RegisterClass> regClasses,
-                                   st::Type *paramType) {
-      std::string locA = this->getRegisterString(regClasses.first, paramType);
-      std::string locB = this->getRegisterString(regClasses.second, paramType);
-
-      // If B is empty (NO_CLASS) then return A
-      if (locB == "") {
-        return locA;
-      }
-      return locA + "|" + locB;
-    }
-
-    // Get a string location from a register class
-    std::string getRegisterString(RegisterClass regClass, st::Type *paramType) {
-      std::optional<std::string> regString;
-
-      // If the class is memory, pass the argument on the stack
-      if (regClass == RegisterClass::NO_CLASS) regString = "";
-      if (regClass == RegisterClass::SSE) regString = this->getNextSseRegister();
-      if (regClass == RegisterClass::INTEGER) regString = this->getNextIntRegister();
-      if (regClass == RegisterClass::MEMORY) regString = std::nullopt;
-
-      // If we don't have a value, we need a framebase
-      if (!regString.has_value()) {
-        regString = fallocator.nextFramebaseFromType(paramType);
+    std::string getRegisterString(RegisterClass lo, RegisterClass hi, st::Type *paramType) {
+      if (lo == RegisterClass::NO_CLASS) {
+        throw std::runtime_error{"Can't allocate a {NO_CLASS, *}"};
       }
 
-      // If we've run out of registers we get to this point
-      return regString.value();
+      if (lo == RegisterClass::MEMORY) {
+        // goes on the stack
+        return fallocator.nextFramebaseFromType(paramType);
+      }
+
+      if (lo == RegisterClass::INTEGER) {
+        auto reg = getNextIntRegister();
+        if (!reg) {
+          // Ran out of registers, put it on the stack
+          return fallocator.nextFramebaseFromType(paramType);
+        }
+        return reg.value();
+      }
+
+      if (lo == RegisterClass::SSE) {
+        auto reg = getNextSseRegister();
+        if (!reg) {
+          // Ran out of registers, put it on the stack
+          return fallocator.nextFramebaseFromType(paramType);
+        }
+
+        if (hi == RegisterClass::SSEUP) {
+          // If the class is SSEUP, the eightbyte is passed in the next available eightbyte
+          // chunk of the last used vector register.
+        }
+        return reg.value();
+
+        /* TODO
+         *
+         *  For objects allocated in multiple registers, use the syntax '%r1 | %r2 | ...'
+         *  to denote this. This can only happen for aggregates.
+         *
+         *  Use ymm and zmm for larger vector types and check for aliasing
+         */
+      }
+
+      if (lo == RegisterClass::X87) {
+        // goes on the stack
+        return fallocator.nextFramebaseFromType(paramType);
+      }
+
+      if (lo == RegisterClass::COMPLEX_X87) {
+        // goes on the stack
+        return fallocator.nextFramebaseFromType(paramType);
+      }
+
+      // This should never be reached
+      throw std::runtime_error{"Unknown classification"};
     }
 
   private:

--- a/source/parser/x86_64/classifiers.hpp
+++ b/source/parser/x86_64/classifiers.hpp
@@ -12,7 +12,7 @@
 
 namespace smeagle::x86_64 {
 
-  struct Class {
+  struct classification {
     RegisterClass lo, hi;
     int pointer_indirections;
     std::string name;
@@ -20,7 +20,7 @@ namespace smeagle::x86_64 {
 
   namespace st = Dyninst::SymtabAPI;
 
-  inline Class classify(st::typeScalar *t, int ptr_cnt) {
+  inline classification classify(st::typeScalar *t, int ptr_cnt) {
     // size in BITS
     const auto size = t->getSize() * 8;
 
@@ -96,10 +96,10 @@ namespace smeagle::x86_64 {
     throw std::runtime_error{"Unknown scalar type"};
   }
 
-  inline Class classify(st::typeStruct *) { return {}; }
-  inline Class classify(st::typeUnion *) { return {}; }
-  inline Class classify(st::typeArray *) { return {}; }
-  inline Class classify(st::typeEnum *) { return {}; }
-  inline Class classify(st::typeFunction *) { return {}; }
+  inline classification classify(st::typeStruct *) { return {}; }
+  inline classification classify(st::typeUnion *) { return {}; }
+  inline classification classify(st::typeArray *) { return {}; }
+  inline classification classify(st::typeEnum *) { return {}; }
+  inline classification classify(st::typeFunction *) { return {}; }
 
 }  // namespace smeagle::x86_64

--- a/source/parser/x86_64/classifiers.hpp
+++ b/source/parser/x86_64/classifiers.hpp
@@ -1,0 +1,105 @@
+// Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+// Spack Project Developers. See the top-level COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+#pragma once
+
+#include <utility>
+
+#include "Type.h"
+#include "register_class.hpp"
+
+namespace smeagle::x86_64 {
+
+  struct Class {
+    RegisterClass lo, hi;
+    int pointer_indirections;
+    std::string name;
+  };
+
+  namespace st = Dyninst::SymtabAPI;
+
+  inline Class classify(st::typeScalar *t, int ptr_cnt) {
+    // size in BITS
+    const auto size = t->getSize() * 8;
+
+    if (ptr_cnt > 0) {
+      /*
+       * A pointer to a type X is converted to three abi_typelocation rules:
+       * 	1) 	A Pointer64 type at the base location and the base direction.
+       *
+       * 	2) 	A recursive conversion of application type X, at location “(base location)”
+       * 		(the base location wrapped in parentheses) and with direction ‘Export’.
+       *
+       * 	3)	A recursive conversion of application type X, at location “(base location)”
+       * 	(the base location wrapped in parentheses) and with direction ‘Import’.
+       *
+       * 	For example, an application type int* at base location %rax and direction ‘Import’
+       * would convert to: abi_typelocation(..., Import, Pointer64, “%rax”). abi_typelocation(...,
+       * Export, Integer32, “(%rax)”). abi_typelocation(..., Import, Integer32, “(%rax)”).
+       *
+       */
+      // TODO Should we integrate the directionality calculation here?
+      return {RegisterClass::INTEGER, RegisterClass::NO_CLASS, ptr_cnt, "Pointer64"};
+    }
+
+    // paramType properties have booleans to indicate types
+    auto const &props = t->properties();
+
+    // Integral types
+    if (props.is_integral || props.is_UTF) {
+      if (size > 128) {
+        return {RegisterClass::SSE, RegisterClass::SSEUP, ptr_cnt,
+                "IntegerVec" + std::to_string(size)};
+      }
+      if (size == 128) {
+        // __int128 is treated as struct{long,long};
+        // This is NOT correct, but we don't handle aggregates yet.
+        // How do we differentiate between __int128 and __m128i?
+        return {RegisterClass::MEMORY, RegisterClass::NO_CLASS, ptr_cnt, "Integer128"};
+      }
+
+      // _Decimal32, _Decimal64, and __m64 are supposed to be SSE.
+      // TODO How can we differentiate them here?
+      return {RegisterClass::INTEGER, RegisterClass::NO_CLASS, ptr_cnt,
+              "Integer" + std::to_string(size)};
+    }
+
+    if (props.is_floating_point) {
+      if (props.is_complex_float) {
+        if (size == 128) {
+          // x87 `complex long double`
+          return {RegisterClass::COMPLEX_X87, RegisterClass::NO_CLASS, ptr_cnt, "CplxFloat128"};
+        }
+        // This is NOT correct.
+        // TODO It should be struct{T r,i;};, but we don't handle aggregates yet
+        std::cout << "CplxFloat: " << t->getName() << " [" << t->getSize() << "]" << std::endl;
+        return {RegisterClass::MEMORY, RegisterClass::NO_CLASS, ptr_cnt,
+                "CplxFloat" + std::to_string(size / 2)};
+      }
+      if (size <= 64) {
+        // 32- or 64-bit floats
+        return {RegisterClass::SSE, RegisterClass::SSEUP, ptr_cnt, "Float" + std::to_string(size)};
+      }
+      if (size == 128) {
+        // x87 `long double` OR __m128[d]
+        // TODO: How do we differntiate the vector type here? Dyninst should help us
+        return {RegisterClass::X87, RegisterClass::X87UP, ptr_cnt, "Float128"};
+      }
+      if (size > 128) {
+        return {RegisterClass::SSE, RegisterClass::SSEUP, ptr_cnt,
+                "FloatVec" + std::to_string(size)};
+      }
+    }
+
+    throw std::runtime_error{"Unknown scalar type"};
+  }
+
+  inline Class classify(st::typeStruct *) { return {}; }
+  inline Class classify(st::typeUnion *) { return {}; }
+  inline Class classify(st::typeArray *) { return {}; }
+  inline Class classify(st::typeEnum *) { return {}; }
+  inline Class classify(st::typeFunction *) { return {}; }
+
+}  // namespace smeagle::x86_64

--- a/source/parser/x86_64/x86_64.cpp
+++ b/source/parser/x86_64/x86_64.cpp
@@ -74,6 +74,25 @@ namespace smeagle::x86_64 {
     if (auto *t = base_type->getScalarType()) {
       return classify(t, ptr_cnt);
     }
+    if (auto *t = base_type->getStructType()) {
+      // page 18 of abi document
+      return classify(t);
+    }
+    if (auto *t = base_type->getUnionType()) {
+      return classify(t);
+    }
+    if (auto *t = base_type->getArrayType()) {
+      return classify(t);
+    }
+    if (auto *t = base_type->getEnumType()) {
+      return classify(t);
+    }
+    if (auto *t = base_type->getFunctionType()) {
+      // This can only be a function pointer
+      return classify(t);
+    }
+
+    throw std::runtime_error{"Unknown parameter type" + paramType->getName()};
   }
 
   std::vector<parameter> parse_parameters(st::Symbol *symbol) {

--- a/source/parser/x86_64/x86_64.cpp
+++ b/source/parser/x86_64/x86_64.cpp
@@ -96,13 +96,8 @@ namespace smeagle::x86_64 {
   }
 
   std::vector<parameter> parse_parameters(st::Symbol *symbol) {
-    // Get the name and type of the symbol
-    std::string sname = symbol->getMangledName();
     st::Function *func = symbol->getFunction();
     std::vector<st::localVar *> params;
-
-    // The function name looks equivalent to the symbol name
-    std::string fname = func->getName();
 
     std::vector<parameter> typelocs;
 

--- a/source/parser/x86_64/x86_64.cpp
+++ b/source/parser/x86_64/x86_64.cpp
@@ -68,7 +68,7 @@ namespace smeagle::x86_64 {
   }
 
   // Get register class given the argument type
-  Class getRegisterClassFromType(st::Type *paramType) {
+  classification getRegisterClassFromType(st::Type *paramType) {
     auto [base_type, ptr_cnt] = unwrap_underlying_type(paramType);
 
     if (auto *t = base_type->getScalarType()) {
@@ -111,7 +111,7 @@ namespace smeagle::x86_64 {
         st::Type *paramType = param->getType();
 
         // Get register class based on type
-        Class c = getRegisterClassFromType(paramType);
+        classification c = getRegisterClassFromType(paramType);
 
         // Get the directionality (export or import) given the type
         std::string direction = getDirectionalityFromType(paramType);

--- a/source/parser/x86_64/x86_64.cpp
+++ b/source/parser/x86_64/x86_64.cpp
@@ -15,6 +15,7 @@
 #include "Symtab.h"
 #include "Type.h"
 #include "allocators.hpp"
+#include "classifiers.hpp"
 #include "smeagle/parameter.h"
 #include "type_checker.hpp"
 
@@ -67,74 +68,12 @@ namespace smeagle::x86_64 {
   }
 
   // Get register class given the argument type
-  std::pair<RegisterClass, RegisterClass> getRegisterClassFromType(st::Type *paramType) {
-    // Remove top-level typedef
-    paramType = remove_typedef(paramType);
+  Class getRegisterClassFromType(st::Type *paramType) {
+    auto [base_type, ptr_cnt] = unwrap_underlying_type(paramType);
 
-    // If it's a pointer, remove it
-    if (is_indirect(paramType->getDataClass())) {
-      paramType = deref(paramType);
-      paramType = remove_typedef(paramType);
+    if (auto *t = base_type->getScalarType()) {
+      return classify(t, ptr_cnt);
     }
-
-    // Now get a string version of the type
-    std::string paramTypeString = paramType->getName();
-
-    // Signed and unsigned Bool,char,short,int,long,long long, and pointers
-    std::regex checkinteger("(int|char|short|long|pointer|bool)");
-
-    // Is it a constant?
-    std::regex checkconstant("(const)");
-
-    // float,double,_Decimal32,_Decimal64and__m64are in class SSE.
-    std::regex checksse("(double|decimal|float|Decimal|m64)");
-
-    // __float128 and__m128are split into two halves, least significant SSE,
-    // most significant in SSEUP.
-    std::regex checksseup("(m128|float128)");
-
-    // The 64-bit mantissa of arguments of type long double belongs to classX87
-    // the 16-bit exponent plus 6 bytes of padding belongs to class X87UP
-    std::regex checklongdouble("(long|double)");
-
-    // A variable of type complex long double is classified as type COMPLEX_X87
-    std::regex checkcomplexlong("(complex long double)");
-
-    // We will return a vector of classes
-    std::pair<RegisterClass, RegisterClass> regClasses;
-
-    // Does the type string match one of the types?
-    bool isinteger = (std::regex_search(paramTypeString, checkinteger));
-    bool isconst = (std::regex_search(paramTypeString, checkconstant));
-    bool issse = (std::regex_search(paramTypeString, checksse));
-    bool issseup = (std::regex_search(paramTypeString, checksseup));
-    bool islongdouble = (std::regex_search(paramTypeString, checklongdouble));
-    bool iscomplexlong = (std::regex_search(paramTypeString, checkcomplexlong));
-
-    // A parameter can have more than one class!
-    if (isconst) {
-      regClasses = {RegisterClass::MEMORY, RegisterClass::NO_CLASS};
-    }
-    if (issseup) {
-      regClasses = {RegisterClass::SSE, RegisterClass::SSEUP};
-    }
-    if (issse) {
-      regClasses = {RegisterClass::SSE, RegisterClass::NO_CLASS};
-    }
-    if (isinteger) {
-      regClasses = {RegisterClass::INTEGER, RegisterClass::NO_CLASS};
-    }
-    if (iscomplexlong) {
-      regClasses = {RegisterClass::COMPLEX_X87, RegisterClass::NO_CLASS};
-    }
-    if (islongdouble) {
-      regClasses = {RegisterClass::X87, RegisterClass::X87UP};
-    }
-
-    // The classification of aggregate (structures and arrays) and union types worksas follows:
-    // TODO need to look for struct / arrays?
-    // page 18 of abi document
-    return regClasses;
   }
 
   std::vector<parameter> parse_parameters(st::Symbol *symbol) {

--- a/source/parser/x86_64/x86_64.cpp
+++ b/source/parser/x86_64/x86_64.cpp
@@ -116,7 +116,7 @@ namespace smeagle::x86_64 {
         st::Type *paramType = param->getType();
 
         // Get register class based on type
-        std::pair<RegisterClass, RegisterClass> regClasses = getRegisterClassFromType(paramType);
+        Class c = getRegisterClassFromType(paramType);
 
         // Get the directionality (export or import) given the type
         std::string direction = getDirectionalityFromType(paramType);
@@ -127,8 +127,8 @@ namespace smeagle::x86_64 {
         // Create a new typelocation to parse later
         parameter p;
         p.name = paramName;
-        p.type = paramType->getName();
-        p.location = allocator.getRegistersString(regClasses, paramType);
+        p.type = c.name;
+        p.location = allocator.getRegisterString(c.lo, c.hi, paramType);
         p.direction = direction;
         typelocs.push_back(p);
       }

--- a/source/parser/x86_64/x86_64.cpp
+++ b/source/parser/x86_64/x86_64.cpp
@@ -45,7 +45,7 @@ namespace smeagle::x86_64 {
   // Get directionality from argument type
   std::string getDirectionalityFromType(st::Type *paramType) {
     // Remove any top-level typedef
-    // NB: We can't call `dedecorate` here as we need to keep
+    // NB: We can't call `unwrap_underlying_type` here as we need to keep
     //     any reference type for the call to `is_indirect` work.
     paramType = remove_typedef(paramType);
     auto dataClass = paramType->getDataClass();

--- a/test/source/allocation.cpp
+++ b/test/source/allocation.cpp
@@ -8,16 +8,13 @@
 
 #include "smeagle/smeagle.h"
 
-auto get_one(smeagle::Corpus const& corpus, char const* name) {
-  auto funcs = corpus.getFunctions();
+auto const& get_one(smeagle::Corpus const& corpus, char const* name) {
+  auto const& funcs = corpus.getFunctions();
 
-  // We only want the "foo" function
-  funcs.erase(std::remove_if(funcs.begin(), funcs.end(),
-                             [name](smeagle::abi_description const& d) {
-                               return d.function_name.find(name) == std::string::npos;
-                             }),
-              funcs.end());
-  return funcs;
+  return *std::find_if(funcs.begin(), funcs.end(),
+					 [name](smeagle::abi_description const& d) {
+					   return d.function_name == name;
+					 });
 }
 
 TEST_CASE("Register Allocation String and char types") {

--- a/test/source/allocation.cpp
+++ b/test/source/allocation.cpp
@@ -17,350 +17,399 @@ auto const& get_one(smeagle::Corpus const& corpus, char const* name) {
 					 });
 }
 
-TEST_CASE("Register Allocation String and char types") {
-  auto corpus = smeagle::Smeagle("liballocation.so").parse();
-
-  SUBCASE("string") {
-    auto funcs = get_one(corpus, "test_stringchar_string");
-    REQUIRE(funcs.size() == 1);
-    auto const& parameters = funcs[0].parameters;
-    CHECK(parameters[0].location == "%rdi");
-  }
-
-  SUBCASE("char") {
-    auto funcs = get_one(corpus, "test_stringchar_char");
-    REQUIRE(funcs.size() == 1);
-    auto const& parameters = funcs[0].parameters;
-    CHECK(parameters[0].location == "%rdi");
-  }
-
-  SUBCASE("wchar_t") {
-    auto funcs = get_one(corpus, "test_stringchar_wchar_t");
-    REQUIRE(funcs.size() == 1);
-    auto const& parameters = funcs[0].parameters;
-    CHECK(parameters[0].location == "%rdi");
-  }
+namespace {
+	auto corpus = smeagle::Smeagle("liballocation.so").parse();
 }
 
-TEST_CASE("Register Allocation Signed String and char types") {
-  auto corpus = smeagle::Smeagle("liballocation.so").parse();
-
-  SUBCASE("signed char") {
-    auto funcs = get_one(corpus, "test_signed_char");
-    REQUIRE(funcs.size() == 1);
-    auto const& parameters = funcs[0].parameters;
-    CHECK(parameters[0].location == "%rdi");
-  }
-}
-
-TEST_CASE("Register Allocation Unsigned String and char types") {
-  auto corpus = smeagle::Smeagle("liballocation.so").parse();
-
-  SUBCASE("unsigned char") {
-    auto funcs = get_one(corpus, "test_unsigned_char");
-    REQUIRE(funcs.size() == 1);
-    auto const& parameters = funcs[0].parameters;
-    CHECK(parameters[0].location == "%rdi");
-  }
-}
-
-TEST_CASE("Register Allocation Float types") {
-  auto corpus = smeagle::Smeagle("liballocation.so").parse();
-
-  SUBCASE("float") {
-    auto funcs = get_one(corpus, "test_float_float");
-    REQUIRE(funcs.size() == 1);
-    auto const& parameters = funcs[0].parameters;
-    CHECK(parameters[0].location == "%xmm0");
-  }
-
-  SUBCASE("double (double floating point)") {
-    auto funcs = get_one(corpus, "test_float_double");
-    REQUIRE(funcs.size() == 1);
-    auto const& parameters = funcs[0].parameters;
-    CHECK(parameters[0].location == "framebase+8|framebase+16");
-  }
-}
-
-TEST_CASE("Register Allocation Unsigned Integral types") {
-  auto corpus = smeagle::Smeagle("liballocation.so").parse();
-
-  SUBCASE("unsigned int") {
-    auto funcs = get_one(corpus, "test_integral_unsigned_int");
-    REQUIRE(funcs.size() == 1);
-    auto const& parameters = funcs[0].parameters;
-    CHECK(parameters[0].location == "%rdi");
-  }
-}
-
-TEST_CASE("Register Allocation Signed Integral types") {
-  auto corpus = smeagle::Smeagle("liballocation.so").parse();
-
-  SUBCASE("signed int") {
-    auto funcs = get_one(corpus, "test_signedintegral_signed_int");
-    REQUIRE(funcs.size() == 1);
-    auto const& parameters = funcs[0].parameters;
-    CHECK(parameters[0].location == "%rdi");
-  }
-}
-
-TEST_CASE("Register Allocation Null types") {
-  auto corpus = smeagle::Smeagle("liballocation.so").parse();
-
-  SUBCASE("void") {
-    auto funcs = get_one(corpus, "test_null_void");
-    REQUIRE(funcs.size() == 1);
-    auto const& parameters = funcs[0].parameters;
-    REQUIRE(parameters.size() == 0);
-  }
-}
-
-TEST_CASE("Register Allocation Boolean types") {
-  auto corpus = smeagle::Smeagle("liballocation.so").parse();
-
+TEST_CASE("Register Allocation - Integral Types") {
   SUBCASE("bool") {
-    auto funcs = get_one(corpus, "test_boolean_boolean");
-    REQUIRE(funcs.size() == 1);
-    auto const& parameters = funcs[0].parameters;
+    auto func = get_one(corpus, "test_bool");
+    auto const& parameters = func.parameters;
+    CHECK(parameters.size() == 1);
     CHECK(parameters[0].location == "%rdi");
+    CHECK(parameters[0].type == "Integer8");
   }
-}
-
-TEST_CASE("Register Allocation Fixed Width Integer types") {
-  auto corpus = smeagle::Smeagle("liballocation.so").parse();
-
-  SUBCASE("int8_t") {
-    auto funcs = get_one(corpus, "test_type_int8_t");
-    REQUIRE(funcs.size() == 1);
-    auto const& parameters = funcs[0].parameters;
+  SUBCASE("char") {
+    auto func = get_one(corpus, "test_char");
+    auto const& parameters = func.parameters;
+    CHECK(parameters.size() == 1);
     CHECK(parameters[0].location == "%rdi");
+    CHECK(parameters[0].type == "Integer8");
   }
-
-  SUBCASE("int16_t") {
-    auto funcs = get_one(corpus, "test_type_int16_t");
-    REQUIRE(funcs.size() == 1);
-    auto const& parameters = funcs[0].parameters;
-    CHECK(parameters[0].location == "%rdi");
-  }
-
-  SUBCASE("int32_t") {
-    auto funcs = get_one(corpus, "test_type_int32_t");
-    REQUIRE(funcs.size() == 1);
-    auto const& parameters = funcs[0].parameters;
-    CHECK(parameters[0].location == "%rdi");
-  }
-
-  SUBCASE("int64_t") {
-    auto funcs = get_one(corpus, "test_type_int64_t");
-    REQUIRE(funcs.size() == 1);
-    auto const& parameters = funcs[0].parameters;
-    CHECK(parameters[0].location == "%rdi");
-  }
-
-  SUBCASE("int_fast8_t") {
-    auto funcs = get_one(corpus, "test_type_int_fast8_t");
-    REQUIRE(funcs.size() == 1);
-    auto const& parameters = funcs[0].parameters;
-    CHECK(parameters[0].location == "%rdi");
-  }
-
-  SUBCASE("int_fast16_t") {
-    auto funcs = get_one(corpus, "test_type_int_fast16_t");
-    REQUIRE(funcs.size() == 1);
-    auto const& parameters = funcs[0].parameters;
-    CHECK(parameters[0].location == "framebase+8|framebase+16");
-  }
-
-  SUBCASE("int_fast32_t") {
-    auto funcs = get_one(corpus, "test_type_int_fast32_t");
-    REQUIRE(funcs.size() == 1);
-    auto const& parameters = funcs[0].parameters;
-    CHECK(parameters[0].location == "framebase+8|framebase+16");
-  }
-
-  SUBCASE("int_fast64_t") {
-    auto funcs = get_one(corpus, "test_type_int_fast64_t");
-    REQUIRE(funcs.size() == 1);
-    auto const& parameters = funcs[0].parameters;
-    CHECK(parameters[0].location == "framebase+8|framebase+16");
-  }
-
-  SUBCASE("int_least8_t") {
-    auto funcs = get_one(corpus, "test_type_int_least8_t");
-    REQUIRE(funcs.size() == 1);
-    auto const& parameters = funcs[0].parameters;
-    CHECK(parameters[0].location == "%rdi");
-  }
-
-  SUBCASE("int_least16_t") {
-    auto funcs = get_one(corpus, "test_type_int_least16_t");
-    REQUIRE(funcs.size() == 1);
-    auto const& parameters = funcs[0].parameters;
-    CHECK(parameters[0].location == "%rdi");
-  }
-
-  SUBCASE("int_least32_t") {
-    auto funcs = get_one(corpus, "test_type_int_least32_t");
-    REQUIRE(funcs.size() == 1);
-    auto const& parameters = funcs[0].parameters;
-    CHECK(parameters[0].location == "%rdi");
-  }
-
-  SUBCASE("int_least64_t") {
-    auto funcs = get_one(corpus, "test_type_int_least64_t");
-    REQUIRE(funcs.size() == 1);
-    auto const& parameters = funcs[0].parameters;
-    CHECK(parameters[0].location == "framebase+8|framebase+16");
-  }
-
-  SUBCASE("uint8_t") {
-    auto funcs = get_one(corpus, "test_type_uint8_t");
-    REQUIRE(funcs.size() == 1);
-    auto const& parameters = funcs[0].parameters;
-    CHECK(parameters[0].location == "%rdi");
-  }
-
-  SUBCASE("uint16_t") {
-    auto funcs = get_one(corpus, "test_type_uint16_t");
-    REQUIRE(funcs.size() == 1);
-    auto const& parameters = funcs[0].parameters;
-    CHECK(parameters[0].location == "%rdi");
-  }
-
-  SUBCASE("uint32_t") {
-    auto funcs = get_one(corpus, "test_type_uint32_t");
-    REQUIRE(funcs.size() == 1);
-    auto const& parameters = funcs[0].parameters;
-    CHECK(parameters[0].location == "%rdi");
-  }
-
-  SUBCASE("uint64_t") {
-    auto funcs = get_one(corpus, "test_type_uint64_t");
-    REQUIRE(funcs.size() == 1);
-    auto const& parameters = funcs[0].parameters;
-    CHECK(parameters[0].location == "%rdi");
-  }
-
-  SUBCASE("uint_fast8_t") {
-    auto funcs = get_one(corpus, "test_type_uint_fast8_t");
-    REQUIRE(funcs.size() == 1);
-    auto const& parameters = funcs[0].parameters;
-    CHECK(parameters[0].location == "%rdi");
-  }
-
-  SUBCASE("uint_fast16_t") {
-    auto funcs = get_one(corpus, "test_type_uint_fast16_t");
-    REQUIRE(funcs.size() == 1);
-    auto const& parameters = funcs[0].parameters;
-    CHECK(parameters[0].location == "framebase+8|framebase+16");
-  }
-
-  SUBCASE("uint_fast32_t") {
-    auto funcs = get_one(corpus, "test_type_uint_fast32_t");
-    REQUIRE(funcs.size() == 1);
-    auto const& parameters = funcs[0].parameters;
-    CHECK(parameters[0].location == "framebase+8|framebase+16");
-  }
-
-  SUBCASE("uint_fast64_t") {
-    auto funcs = get_one(corpus, "test_type_uint_fast64_t");
-    REQUIRE(funcs.size() == 1);
-    auto const& parameters = funcs[0].parameters;
-    CHECK(parameters[0].location == "framebase+8|framebase+16");
-  }
-
-  SUBCASE("uint_least8_t") {
-    auto funcs = get_one(corpus, "test_type_uint_least8_t");
-    REQUIRE(funcs.size() == 1);
-    auto const& parameters = funcs[0].parameters;
-    CHECK(parameters[0].location == "%rdi");
-  }
-
-  SUBCASE("uint_least16_t") {
-    auto funcs = get_one(corpus, "test_type_uint_least16_t");
-    REQUIRE(funcs.size() == 1);
-    auto const& parameters = funcs[0].parameters;
-    CHECK(parameters[0].location == "%rdi");
-  }
-
-  SUBCASE("uint_least32_t") {
-    auto funcs = get_one(corpus, "test_type_uint_least32_t");
-    REQUIRE(funcs.size() == 1);
-    auto const& parameters = funcs[0].parameters;
-    CHECK(parameters[0].location == "%rdi");
-  }
-
-  SUBCASE("uint_least64_t") {
-    auto funcs = get_one(corpus, "test_type_uint_least64_t");
-    REQUIRE(funcs.size() == 1);
-    auto const& parameters = funcs[0].parameters;
-    CHECK(parameters[0].location == "framebase+8|framebase+16");
-  }
-
-  SUBCASE("intmax_t") {
-    auto funcs = get_one(corpus, "test_type_intmax_t");
-    REQUIRE(funcs.size() == 1);
-    auto const& parameters = funcs[0].parameters;
-    CHECK(parameters[0].location == "%rdi");
-  }
-
-  SUBCASE("intptr_t") {
-    auto funcs = get_one(corpus, "test_type_intptr_t");
-    REQUIRE(funcs.size() == 1);
-    auto const& parameters = funcs[0].parameters;
-    CHECK(parameters[0].location == "framebase+8|framebase+16");
-  }
-
-  SUBCASE("uintmax_t") {
-    auto funcs = get_one(corpus, "test_type_uintmax_t");
-    REQUIRE(funcs.size() == 1);
-    auto const& parameters = funcs[0].parameters;
-    CHECK(parameters[0].location == "%rdi");
-  }
-
-  SUBCASE("uintptr_t") {
-    auto funcs = get_one(corpus, "test_type_uintptr_t");
-    REQUIRE(funcs.size() == 1);
-    auto const& parameters = funcs[0].parameters;
-    CHECK(parameters[0].location == "framebase+8|framebase+16");
-  }
-}
-
-TEST_CASE("Register Allocation Integral types") {
-  auto corpus = smeagle::Smeagle("liballocation.so").parse();
-
-  SUBCASE("int") {
-    auto funcs = get_one(corpus, "test_single_int");
-    REQUIRE(funcs.size() == 1);
-    auto const& parameters = funcs[0].parameters;
-    CHECK(parameters[0].location == "%rdi");
-  }
-
   SUBCASE("short") {
-    auto funcs = get_one(corpus, "test_type_short");
-    REQUIRE(funcs.size() == 1);
-    auto const& parameters = funcs[0].parameters;
+    auto func = get_one(corpus, "test_short");
+    auto const& parameters = func.parameters;
+    CHECK(parameters.size() == 1);
+    CHECK(parameters[0].location == "%rdi");
+    CHECK(parameters[0].type == "Integer16");
+  }
+  SUBCASE("int") {
+    auto func = get_one(corpus, "test_int");
+    auto const& parameters = func.parameters;
+    CHECK(parameters.size() == 1);
+    CHECK(parameters[0].location == "%rdi");
+    CHECK(parameters[0].type == "Integer32");
+  }
+  SUBCASE("long") {
+    auto func = get_one(corpus, "test_long");
+    auto const& parameters = func.parameters;
+    CHECK(parameters.size() == 1);
+    CHECK(parameters[0].location == "%rdi");
+    CHECK(parameters[0].type == "Integer64");
+  }
+  SUBCASE("long long") {
+    auto func = get_one(corpus, "test_long_long");
+    auto const& parameters = func.parameters;
+    CHECK(parameters.size() == 1);
+    CHECK(parameters[0].location == "%rdi");
+    CHECK(parameters[0].type == "Integer64");
+  }
+}
+TEST_CASE("Register Allocation - Signed Integral Types") {
+  SUBCASE("signed") {
+    auto func = get_one(corpus, "test_signed");
+    auto const& parameters = func.parameters;
+    CHECK(parameters.size() == 1);
+    CHECK(parameters[0].location == "%rdi");
+    CHECK(parameters[0].type == "Integer32");
+  }
+  SUBCASE("signed char") {
+    auto func = get_one(corpus, "test_signed_char");
+    auto const& parameters = func.parameters;
+    CHECK(parameters.size() == 1);
+    CHECK(parameters[0].location == "%rdi");
+    CHECK(parameters[0].type == "Integer8");
+  }
+  SUBCASE("signed short") {
+    auto func = get_one(corpus, "test_signed_short");
+    auto const& parameters = func.parameters;
+    CHECK(parameters.size() == 1);
+    CHECK(parameters[0].location == "%rdi");
+    CHECK(parameters[0].type == "Integer16");
+  }
+  SUBCASE("signed int") {
+    auto func = get_one(corpus, "test_signed_int");
+    auto const& parameters = func.parameters;
+    CHECK(parameters.size() == 1);
+    CHECK(parameters[0].location == "%rdi");
+    CHECK(parameters[0].type == "Integer32");
+  }
+  SUBCASE("signed long") {
+    auto func = get_one(corpus, "test_signed_long");
+    auto const& parameters = func.parameters;
+    CHECK(parameters.size() == 1);
+    CHECK(parameters[0].location == "%rdi");
+    CHECK(parameters[0].type == "Integer64");
+  }
+  SUBCASE("signed long long") {
+    auto func = get_one(corpus, "test_signed_long_long");
+    auto const& parameters = func.parameters;
+    CHECK(parameters.size() == 1);
+    CHECK(parameters[0].location == "%rdi");
+    CHECK(parameters[0].type == "Integer64");
+  }
+}
+TEST_CASE("Register Allocation - Unsigned Integral Types") {
+  SUBCASE("unsigned") {
+    auto func = get_one(corpus, "test_unsigned");
+    auto const& parameters = func.parameters;
+    CHECK(parameters.size() == 1);
+    CHECK(parameters[0].location == "%rdi");
+    CHECK(parameters[0].type == "Integer32");
+  }
+  SUBCASE("unsigned char") {
+    auto func = get_one(corpus, "test_unsigned_char");
+    auto const& parameters = func.parameters;
+    CHECK(parameters.size() == 1);
+    CHECK(parameters[0].location == "%rdi");
+    CHECK(parameters[0].type == "Integer8");
+  }
+  SUBCASE("unsigned short") {
+    auto func = get_one(corpus, "test_unsigned_short");
+    auto const& parameters = func.parameters;
+    CHECK(parameters.size() == 1);
+    CHECK(parameters[0].location == "%rdi");
+    CHECK(parameters[0].type == "Integer16");
+  }
+  SUBCASE("unsigned int") {
+    auto func = get_one(corpus, "test_unsigned_int");
+    auto const& parameters = func.parameters;
+    CHECK(parameters.size() == 1);
+    CHECK(parameters[0].location == "%rdi");
+    CHECK(parameters[0].type == "Integer32");
+  }
+  SUBCASE("unsigned long") {
+    auto func = get_one(corpus, "test_unsigned_long");
+    auto const& parameters = func.parameters;
+    CHECK(parameters.size() == 1);
+    CHECK(parameters[0].location == "%rdi");
+    CHECK(parameters[0].type == "Integer64");
+  }
+  SUBCASE("unsigned long long") {
+    auto func = get_one(corpus, "test_unsigned_long_long");
+    auto const& parameters = func.parameters;
+    CHECK(parameters.size() == 1);
+    CHECK(parameters[0].location == "%rdi");
+    CHECK(parameters[0].type == "Integer64");
+  }
+}
+TEST_CASE("Register Allocation - Floating Point Types") {
+  SUBCASE("float") {
+    auto func = get_one(corpus, "test_float");
+    auto const& parameters = func.parameters;
+    CHECK(parameters.size() == 1);
+    CHECK(parameters[0].location == "%xmm0");
+    CHECK(parameters[0].type == "Float32");
+  }
+  SUBCASE("double") {
+    auto func = get_one(corpus, "test_double");
+    auto const& parameters = func.parameters;
+    CHECK(parameters.size() == 1);
+    CHECK(parameters[0].location == "%xmm0");
+    CHECK(parameters[0].type == "Float64");
+  }
+  SUBCASE("long double") {
+    auto func = get_one(corpus, "test_long_double");
+    auto const& parameters = func.parameters;
+    CHECK(parameters.size() == 1);
+    CHECK(parameters[0].location == "framebase+8");
+    CHECK(parameters[0].type == "Float128");
+  }
+  SUBCASE("float _Complex") {
+    auto func = get_one(corpus, "test_float__Complex");
+    auto const& parameters = func.parameters;
+    CHECK(parameters.size() == 1);
+    CHECK(parameters[0].location == "framebase+8");
+    CHECK(parameters[0].type == "CplxFloat32");
+  }
+  SUBCASE("double _Complex") {
+    auto func = get_one(corpus, "test_double__Complex");
+    auto const& parameters = func.parameters;
+    CHECK(parameters.size() == 1);
+    CHECK(parameters[0].location == "framebase+8");
+    CHECK(parameters[0].type == "CplxFloat128");
+  }
+  SUBCASE("long double _Complex") {
+    auto func = get_one(corpus, "test_long_double__Complex");
+    auto const& parameters = func.parameters;
+    CHECK(parameters.size() == 1);
+    CHECK(parameters[0].location == "framebase+8");
+    CHECK(parameters[0].type == "CplxFloat128");
+  }
+}
+TEST_CASE("Register Allocation - UTF Types") {
+  SUBCASE("wchar_t") {
+    auto func = get_one(corpus, "test_wchar_t");
+    auto const& parameters = func.parameters;
+    CHECK(parameters.size() == 1);
+    CHECK(parameters[0].location == "%rdi");
+    CHECK(parameters[0].type == "Integer32");
+  }
+  SUBCASE("char16_t") {
+    auto func = get_one(corpus, "test_char16_t");
+    auto const& parameters = func.parameters;
+    CHECK(parameters.size() == 1);
+    CHECK(parameters[0].location == "%rdi");
+    CHECK(parameters[0].type == "Integer16");
+  }
+  SUBCASE("char32_t") {
+    auto func = get_one(corpus, "test_char32_t");
+    auto const& parameters = func.parameters;
+    CHECK(parameters.size() == 1);
+    CHECK(parameters[0].location == "%rdi");
+    CHECK(parameters[0].type == "Integer32");
+  }
+}
+TEST_CASE("Register Allocation - Size Types") {
+  SUBCASE("size_t") {
+    auto func = get_one(corpus, "test_size_t");
+    auto const& parameters = func.parameters;
+    CHECK(parameters.size() == 1);
+    CHECK(parameters[0].location == "%rdi");
+    CHECK(parameters[0].type == "Integer64");
+  }
+  SUBCASE("intmax_t") {
+    auto func = get_one(corpus, "test_intmax_t");
+    auto const& parameters = func.parameters;
+    CHECK(parameters.size() == 1);
+    CHECK(parameters[0].location == "%rdi");
+    CHECK(parameters[0].type == "Integer64");
+  }
+  SUBCASE("uintmax_t") {
+    auto func = get_one(corpus, "test_uintmax_t");
+    auto const& parameters = func.parameters;
+    CHECK(parameters.size() == 1);
+    CHECK(parameters[0].location == "%rdi");
+    CHECK(parameters[0].type == "Integer64");
+  }
+  SUBCASE("intptr_t") {
+    auto func = get_one(corpus, "test_intptr_t");
+    auto const& parameters = func.parameters;
+    CHECK(parameters.size() == 1);
+    CHECK(parameters[0].location == "%rdi");
+    CHECK(parameters[0].type == "Integer64");
+  }
+  SUBCASE("uintptr_t") {
+    auto func = get_one(corpus, "test_uintptr_t");
+    auto const& parameters = func.parameters;
+    CHECK(parameters.size() == 1);
+    CHECK(parameters[0].location == "%rdi");
+    CHECK(parameters[0].type == "Integer64");
+  }
+}
+TEST_CASE("Register Allocation - Fixed-width Integral Types") {
+  SUBCASE("int8_t") {
+    auto func = get_one(corpus, "test_int8_t");
+    auto const& parameters = func.parameters;
+    CHECK(parameters.size() == 1);
     CHECK(parameters[0].location == "%rdi");
   }
-
-  SUBCASE("long") {
-    auto funcs = get_one(corpus, "test_type_single_long");
-    REQUIRE(funcs.size() == 1);
-    auto const& parameters = funcs[0].parameters;
-    CHECK(parameters[0].location == "framebase+8|framebase+16");
+  SUBCASE("int16_t") {
+    auto func = get_one(corpus, "test_int16_t");
+    auto const& parameters = func.parameters;
+    CHECK(parameters.size() == 1);
+    CHECK(parameters[0].location == "%rdi");
   }
-
-  SUBCASE("long long") {
-    auto funcs = get_one(corpus, "test_type_long_long");
-    REQUIRE(funcs.size() == 1);
-    auto const& parameters = funcs[0].parameters;
-    CHECK(parameters[0].location == "framebase+8|framebase+16");
+  SUBCASE("int32_t") {
+    auto func = get_one(corpus, "test_int32_t");
+    auto const& parameters = func.parameters;
+    CHECK(parameters.size() == 1);
+    CHECK(parameters[0].location == "%rdi");
   }
+  SUBCASE("int64_t") {
+    auto func = get_one(corpus, "test_int64_t");
+    auto const& parameters = func.parameters;
+    CHECK(parameters.size() == 1);
+    CHECK(parameters[0].location == "%rdi");
+  }
+  SUBCASE("int_fast8_t") {
+    auto func = get_one(corpus, "test_int_fast8_t");
+    auto const& parameters = func.parameters;
+    CHECK(parameters.size() == 1);
+    CHECK(parameters[0].location == "%rdi");
+  }
+  SUBCASE("int_fast16_t") {
+    auto func = get_one(corpus, "test_int_fast16_t");
+    auto const& parameters = func.parameters;
+    CHECK(parameters.size() == 1);
+    CHECK(parameters[0].location == "%rdi");
+  }
+  SUBCASE("int_fast32_t") {
+    auto func = get_one(corpus, "test_int_fast32_t");
+    auto const& parameters = func.parameters;
+    CHECK(parameters.size() == 1);
+    CHECK(parameters[0].location == "%rdi");
+  }
+  SUBCASE("int_fast64_t") {
+    auto func = get_one(corpus, "test_int_fast64_t");
+    auto const& parameters = func.parameters;
+    CHECK(parameters.size() == 1);
+    CHECK(parameters[0].location == "%rdi");
+  }
+  SUBCASE("int_least8_t") {
+    auto func = get_one(corpus, "test_int_least8_t");
+    auto const& parameters = func.parameters;
+    CHECK(parameters.size() == 1);
+    CHECK(parameters[0].location == "%rdi");
+  }
+  SUBCASE("int_least16_t") {
+    auto func = get_one(corpus, "test_int_least16_t");
+    auto const& parameters = func.parameters;
+    CHECK(parameters.size() == 1);
+    CHECK(parameters[0].location == "%rdi");
+  }
+  SUBCASE("int_least32_t") {
+    auto func = get_one(corpus, "test_int_least32_t");
+    auto const& parameters = func.parameters;
+    CHECK(parameters.size() == 1);
+    CHECK(parameters[0].location == "%rdi");
+  }
+  SUBCASE("int_least64_t") {
+    auto func = get_one(corpus, "test_int_least64_t");
+    auto const& parameters = func.parameters;
+    CHECK(parameters.size() == 1);
+    CHECK(parameters[0].location == "%rdi");
+  }
+}
+TEST_CASE("Register Allocation - Unsigned Fixed-width Integral Types") {
+  SUBCASE("uint8_t") {
+    auto func = get_one(corpus, "test_uint8_t");
+    auto const& parameters = func.parameters;
+    CHECK(parameters.size() == 1);
+    CHECK(parameters[0].location == "%rdi");
+  }
+  SUBCASE("uint16_t") {
+    auto func = get_one(corpus, "test_uint16_t");
+    auto const& parameters = func.parameters;
+    CHECK(parameters.size() == 1);
+    CHECK(parameters[0].location == "%rdi");
+  }
+  SUBCASE("uint32_t") {
+    auto func = get_one(corpus, "test_uint32_t");
+    auto const& parameters = func.parameters;
+    CHECK(parameters.size() == 1);
+    CHECK(parameters[0].location == "%rdi");
+  }
+  SUBCASE("uint64_t") {
+    auto func = get_one(corpus, "test_uint64_t");
+    auto const& parameters = func.parameters;
+    CHECK(parameters.size() == 1);
+    CHECK(parameters[0].location == "%rdi");
+  }
+  SUBCASE("uint_fast8_t") {
+    auto func = get_one(corpus, "test_uint_fast8_t");
+    auto const& parameters = func.parameters;
+    CHECK(parameters.size() == 1);
+    CHECK(parameters[0].location == "%rdi");
+  }
+  SUBCASE("uint_fast16_t") {
+    auto func = get_one(corpus, "test_uint_fast16_t");
+    auto const& parameters = func.parameters;
+    CHECK(parameters.size() == 1);
+    CHECK(parameters[0].location == "%rdi");
+  }
+  SUBCASE("uint_fast32_t") {
+    auto func = get_one(corpus, "test_uint_fast32_t");
+    auto const& parameters = func.parameters;
+    CHECK(parameters.size() == 1);
+    CHECK(parameters[0].location == "%rdi");
+  }
+  SUBCASE("uint_fast64_t") {
+    auto func = get_one(corpus, "test_uint_fast64_t");
+    auto const& parameters = func.parameters;
+    CHECK(parameters.size() == 1);
+    CHECK(parameters[0].location == "%rdi");
+  }
+  SUBCASE("uint_least8_t") {
+    auto func = get_one(corpus, "test_uint_least8_t");
+    auto const& parameters = func.parameters;
+    CHECK(parameters.size() == 1);
+    CHECK(parameters[0].location == "%rdi");
+  }
+  SUBCASE("uint_least16_t") {
+    auto func = get_one(corpus, "test_uint_least16_t");
+    auto const& parameters = func.parameters;
+    CHECK(parameters.size() == 1);
+    CHECK(parameters[0].location == "%rdi");
+  }
+  SUBCASE("uint_least32_t") {
+    auto func = get_one(corpus, "test_uint_least32_t");
+    auto const& parameters = func.parameters;
+    CHECK(parameters.size() == 1);
+    CHECK(parameters[0].location == "%rdi");
+  }
+  SUBCASE("uint_least64_t") {
+    auto func = get_one(corpus, "test_uint_least64_t");
+    auto const& parameters = func.parameters;
+    CHECK(parameters.size() == 1);
+    CHECK(parameters[0].location == "%rdi");
+  }
+}
 
-  SUBCASE("size_t") {
-    auto funcs = get_one(corpus, "test_type_size_t");
-    REQUIRE(funcs.size() == 1);
-    auto const& parameters = funcs[0].parameters;
-    CHECK(parameters[0].location == "framebase+8|framebase+16");
+TEST_CASE("Register Allocation - Null Types") {
+  SUBCASE("void") {
+    auto const& func = get_one(corpus, "test_void");
+    auto const& parameters = func.parameters;
+    CHECK(parameters.size() == 0UL);
   }
 }

--- a/test/source/libs/allocation.cpp
+++ b/test/source/libs/allocation.cpp
@@ -1,69 +1,80 @@
 // Functions to test register allocation
 
 #include <iostream>
+#include <complex.h>
 
-// Register Allocation String and char types
-void test_stringchar_char(char x) {}
-void test_stringchar_string(std::string x) {}
-void test_stringchar_wchar_t(wchar_t x) {}
 
-// Register Allocation Signed String and char types
-void test_signed_char(signed char x) {}
+// Integral Types
+extern "C" void test_bool(bool x){}
+extern "C" void test_char(char x){}
+extern "C" void test_short(short x){}
+extern "C" void test_int(int x){}
+extern "C" void test_long(long x){}
+extern "C" void test_long_long(long long x){}
 
-// Register Allocation Unsigned String and char types
-void test_unsigned_char(unsigned char x) {}
+// Signed Integral Types
+extern "C" void test_signed(signed x){}
+extern "C" void test_signed_char(signed char x){}
+extern "C" void test_signed_short(signed short x){}
+extern "C" void test_signed_int(signed int x){}
+extern "C" void test_signed_long(signed long x){}
+extern "C" void test_signed_long_long(signed long long x){}
 
-// Register Allocation Float types
-void test_float_float(float x) {}
-void test_float_double(double x) {}
+// Unigned Integral Types
+extern "C" void test_unsigned(unsigned x){}
+extern "C" void test_unsigned_char(unsigned char x){}
+extern "C" void test_unsigned_short(unsigned short x){}
+extern "C" void test_unsigned_int(unsigned int x){}
+extern "C" void test_unsigned_long(unsigned long x){}
+extern "C" void test_unsigned_long_long(unsigned long long x){}
 
-// Register Allocation Unsigned Integral types
-void test_integral_unsigned_int(unsigned int x) {}
+// Floating Point Types
+extern "C" void test_float(float x){}
+extern "C" void test_double(double x){}
+extern "C" void test_long_double(long double x){}
+extern "C" void test_float__Complex(float _Complex x){}
+extern "C" void test_double__Complex(double _Complex x){}
+extern "C" void test_long_double__Complex(long double _Complex x){}
 
-// Register Allocation Signed Integral types
-void test_signedintegral_signed_int(signed int x) {}
+// Size Types
+extern "C" void test_wchar_t(wchar_t x){}
+extern "C" void test_char16_t(char16_t x){}
+extern "C" void test_char32_t(char32_t x){}
 
-// Register Allocation Null types
-void test_null_void() {}
+// Size Types
+extern "C" void test_size_t(size_t x){}
+extern "C" void test_intmax_t(intmax_t x){}
+extern "C" void test_uintmax_t(uintmax_t x){}
+extern "C" void test_intptr_t(intptr_t x){}
+extern "C" void test_uintptr_t(uintptr_t x){}
 
-// Register Allocation Boolean types
-void test_boolean_boolean(bool x) {}
+// Fixed-width Integral Types
+extern "C" void test_int8_t(int8_t x){}
+extern "C" void test_int16_t(int16_t x){}
+extern "C" void test_int32_t(int32_t x){}
+extern "C" void test_int64_t(int64_t x){}
+extern "C" void test_int_fast8_t(int_fast8_t x){}
+extern "C" void test_int_fast16_t(int_fast16_t x){}
+extern "C" void test_int_fast32_t(int_fast32_t x){}
+extern "C" void test_int_fast64_t(int_fast64_t x){}
+extern "C" void test_int_least8_t(int_least8_t x){}
+extern "C" void test_int_least16_t(int_least16_t x){}
+extern "C" void test_int_least32_t(int_least32_t x){}
+extern "C" void test_int_least64_t(int_least64_t x){}
 
-// Register Allocation Integral types
-void test_single_int(int x) {}
-void test_type_short(short x) {}
-void test_type_single_long(long x) {}
-void test_type_long_long(long long x) {}
-void test_type_size_t(size_t x) {}
+// Unsigned Fixed-width Integral Types
+extern "C" void test_uint8_t(uint8_t x){}
+extern "C" void test_uint16_t(uint16_t x){}
+extern "C" void test_uint32_t(uint32_t x){}
+extern "C" void test_uint64_t(uint64_t x){}
+extern "C" void test_uint_fast8_t(uint_fast8_t x){}
+extern "C" void test_uint_fast16_t(uint_fast16_t x){}
+extern "C" void test_uint_fast32_t(uint_fast32_t x){}
+extern "C" void test_uint_fast64_t(uint_fast64_t x){}
+extern "C" void test_uint_least8_t(uint_least8_t x){}
+extern "C" void test_uint_least16_t(uint_least16_t x){}
+extern "C" void test_uint_least32_t(uint_least32_t x){}
+extern "C" void test_uint_least64_t(uint_least64_t x){}
 
-// Register Allocation Fixed Width Integer types
-void test_type_int8_t(int8_t x) {}
-void test_type_int16_t(int16_t x) {}
-void test_type_int32_t(int32_t x) {}
-void test_type_int64_t(int64_t x) {}
-void test_type_int_fast8_t(int_fast8_t x) {}
-void test_type_int_fast16_t(int_fast16_t x) {}
-void test_type_int_fast32_t(int_fast32_t x) {}
-void test_type_int_fast64_t(int_fast64_t x) {}
-void test_type_int_least8_t(int_least8_t x) {}
-void test_type_int_least16_t(int_least16_t x) {}
-void test_type_int_least32_t(int_least32_t x) {}
-void test_type_int_least64_t(int_least64_t x) {}
-
-void test_type_intmax_t(intmax_t x) {}
-void test_type_intptr_t(intptr_t x) {}
-void test_type_uintmax_t(uintmax_t x) {}
-void test_type_uintptr_t(uintptr_t x) {}
-
-void test_type_uint8_t(uint8_t x) {}
-void test_type_uint16_t(uint16_t x) {}
-void test_type_uint32_t(uint32_t x) {}
-void test_type_uint64_t(uint64_t x) {}
-void test_type_uint_fast8_t(uint_fast8_t x) {}
-void test_type_uint_fast16_t(uint_fast16_t x) {}
-void test_type_uint_fast32_t(uint_fast32_t x) {}
-void test_type_uint_fast64_t(uint_fast64_t x) {}
-void test_type_uint_least8_t(uint_least8_t x) {}
-void test_type_uint_least16_t(uint_least16_t x) {}
-void test_type_uint_least32_t(uint_least32_t x) {}
-void test_type_uint_least64_t(uint_least64_t x) {}
+// Register Allocation - Null Type
+extern "C" void test_void(){}

--- a/test/source/libs/gen_allocation.py
+++ b/test/source/libs/gen_allocation.py
@@ -1,0 +1,168 @@
+from optparse import OptionParser
+parser = OptionParser()
+parser.add_option('-t', '--tests', dest='test_filename', help='Write test cases to FILE', metavar='FILE')
+parser.add_option('-f', '--funcs', dest='func_filename', help='Write test functions to FILE', metavar='FILE')
+(options, args) = parser.parse_args()
+
+if options.test_filename is None:
+    parser.print_help()
+    exit()
+if options.func_filename is None:
+    parser.print_help()
+    exit()
+
+# ------------------------------------------ #
+
+types = [
+    {
+        'category': "Integral Types",
+        'types': [
+            {'name':'bool',      'type':'Integer8',  'res':'%rdi'},
+            {'name':'char',      'type':'Integer8',  'res':'%rdi'},
+            {'name':'short',     'type':'Integer16', 'res':'%rdi'},
+            {'name':'int',       'type':'Integer32', 'res':'%rdi'},
+            {'name':'long',      'type':'Integer64', 'res':'%rdi'},
+            {'name':'long long', 'type':'Integer64', 'res':'%rdi'}
+        ]
+    },
+    {
+        'category': "Signed Integral Types",
+        'types': [
+            {'name':'signed',           'type':'Integer32', 'res':'%rdi'},
+            {'name':'signed char',      'type':'Integer8',  'res':'%rdi'},
+            {'name':'signed short',     'type':'Integer16', 'res':'%rdi'},
+            {'name':'signed int',       'type':'Integer32', 'res':'%rdi'},
+            {'name':'signed long',      'type':'Integer64', 'res':'%rdi'},
+            {'name':'signed long long', 'type':'Integer64', 'res':'%rdi'}
+        ]
+    },
+    {
+        'category': "Unsigned Integral Types",
+        'types': [
+            {'name':'unsigned',           'type':'Integer32', 'res':'%rdi'},
+            {'name':'unsigned char',      'type':'Integer8',  'res':'%rdi'},
+            {'name':'unsigned short',     'type':'Integer16', 'res':'%rdi'},
+            {'name':'unsigned int',       'type':'Integer32', 'res':'%rdi'},
+            {'name':'unsigned long',      'type':'Integer64', 'res':'%rdi'},
+            {'name':'unsigned long long', 'type':'Integer64', 'res':'%rdi'}
+        ]
+    },
+    {
+        'category': "Floating Point Types",
+        'types': [
+            {'name':'float',                'type':'Float32',      'res':'%xmm0'},
+            {'name':'double',               'type':'Float64',      'res':'%xmm0'},
+            {'name':'long double',          'type':'Float128',     'res':'framebase+8'},
+            {'name':'float _Complex',       'type':'CplxFloat32',  'res':'framebase+8'},
+            {'name':'double _Complex',      'type':'CplxFloat64',  'res':'framebase+8'},
+            {'name':'long double _Complex', 'type':'CplxFloat128', 'res':'framebase+8'}
+        ]
+    },
+    {
+        'category': "UTF Types",
+        'types': [
+            {'name':'wchar_t',  'type':'Integer32', 'res':'%rdi'},
+            {'name':'char16_t', 'type':'Integer16', 'res':'%rdi'},
+            {'name':'char32_t', 'type':'Integer32', 'res':'%rdi'}
+        ]
+    },
+    {
+        'category': "Size Types",
+        'types': [
+            {'name':'size_t',    'type':'Integer64', 'res':'%rdi'},
+            {'name':'intmax_t',  'type':'Integer64', 'res':'%rdi'},
+            {'name':'uintmax_t', 'type':'Integer64', 'res':'%rdi'},
+            {'name':'intptr_t',  'type':'Integer64', 'res':'%rdi'},
+            {'name':'uintptr_t', 'type':'Integer64', 'res':'%rdi'}
+        ]
+    },
+    {
+        # Compilers are free to choose any size, so we don't try to test it here
+        'category': "Fixed-width Integral Types",
+        'types': [
+            {'name':'int8_t',        'res':'%rdi'},
+            {'name':'int16_t',       'res':'%rdi'},
+            {'name':'int32_t',       'res':'%rdi'},
+            {'name':'int64_t',       'res':'%rdi'},
+            {'name':'int_fast8_t',   'res':'%rdi'},
+            {'name':'int_fast16_t',  'res':'%rdi'},
+            {'name':'int_fast32_t',  'res':'%rdi'},
+            {'name':'int_fast64_t',  'res':'%rdi'},
+            {'name':'int_least8_t',  'res':'%rdi'},
+            {'name':'int_least16_t', 'res':'%rdi'},
+            {'name':'int_least32_t', 'res':'%rdi'},
+            {'name':'int_least64_t', 'res':'%rdi'}
+        ]
+    },
+    {
+        # Compilers are free to choose any size, so we don't try to test it here
+        'category': "Unsigned Fixed-width Integral Types",
+        'types': [
+            {'name':'uint8_t',        'res':'%rdi'},
+            {'name':'uint16_t',       'res':'%rdi'},
+            {'name':'uint32_t',       'res':'%rdi'},
+            {'name':'uint64_t',       'res':'%rdi'},
+            {'name':'uint_fast8_t',   'res':'%rdi'},
+            {'name':'uint_fast16_t',  'res':'%rdi'},
+            {'name':'uint_fast32_t',  'res':'%rdi'},
+            {'name':'uint_fast64_t',  'res':'%rdi'},
+            {'name':'uint_least8_t',  'res':'%rdi'},
+            {'name':'uint_least16_t', 'res':'%rdi'},
+            {'name':'uint_least32_t', 'res':'%rdi'},
+            {'name':'uint_least64_t', 'res':'%rdi'}
+        ]
+    }
+]
+
+# ------------------------------------------ #
+
+def make_funcs(file, category, types):
+    file.write("\n// {}\n".format(category))
+    for t in types:
+        name = t['name'].replace(' ', '_')
+        file.write('extern "C" void test_{0}({1} x){{}}\n'.format(name, t['name']))
+
+def make_tests(file, category, types):
+    file.write('TEST_CASE("Register Allocation - {}") {{'.format(category))
+    for t in types:
+        name = t['name'].replace(' ', '_')
+        file.write(
+"""
+  SUBCASE("{0}") {{
+    auto func = get_one(corpus, "test_{1}");
+    auto const& parameters = func.parameters;
+    CHECK(parameters.size() == 1);
+    CHECK(parameters[0].location == "{2}");
+""".format(t['name'], name, t['res'])
+        )
+        if 'type' in t:
+            file.write('    CHECK(parameters[0].type == "{0}");\n'.format(t['type']))
+        file.write('  }')
+    
+    file.write("\n}\n")
+
+# ------------------------------------------ #
+
+with open(options.test_filename, 'w') as test_file:
+    with open(options.func_filename, 'w') as func_file:
+        for t in types:
+            make_funcs(func_file, t['category'], t['types'])
+            make_tests(test_file, t['category'], t['types'])
+        
+        # Null type
+        func_file.write(
+"""
+// Register Allocation - Null Type
+extern "C" void test_void(){}
+""")
+
+        test_file.write(
+"""
+TEST_CASE("Register Allocation - Null Types") {
+  SUBCASE("void") {
+    auto const& func = get_one(corpus, "test_void");
+    auto const& parameters = func.parameters;
+    CHECK(parameters.size() == 0UL);
+  }
+}
+""")


### PR DESCRIPTION
There are three big changes here:

1. Use Dyninst's type information to classify language types into ABI types
2. Expand the register allocator to handle more cases
3. Use a Python script to generate tests and test functions

There are a _lot_ of TODOs hanging around because I kept running into corner cases that I don't have a good answer to right now. We'll need to eventually figure them out, but some of them are the same problems that the LLVM folks haven't implemented yet, either.