### PR TITLE
Fixing bug with yaml quoting

### DIFF
--- a/source/corpora.cpp
+++ b/source/corpora.cpp
@@ -34,11 +34,11 @@ void Corpus::toYaml() {
   std::cout << "library: \"" << library << "\"\nlocations: " << std::endl;
 
   for (auto &f : functions) {
-    std::cout << "  - function:\n      name: " << f.function_name << "\n      parameters:";
+    std::cout << "  - function:\n      name: \"" << f.function_name << "\"\n      parameters:";
     for (auto const &p : f.parameters) {
-      std::cout << "\n        - name: " << p.name << "\n          type: " << p.type
-                << "\n          location: " << p.location
-                << "\n          direction: " << p.direction;
+      std::cout << "\n        - name: \"" << p.name << "\"\n          type: \"" << p.type
+                << "\"\n          location: \"" << p.location << "\"\n          direction: \""
+                << p.direction << "\"";
     }
     std::cout << std::endl;
   }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -37,7 +37,6 @@ add_library(allocation MODULE source/libs/allocation.cpp)
 target_compile_options(allocation PRIVATE "-g")
 set_source_files_properties(source/libs/allocation.cpp PROPERTIES COMPILE_OPTIONS "-O0")
 
-
 # ---- Create binary ----
 add_executable(
   SmeagleTests source/main.cpp source/smeagle.cpp source/directionality.cpp source/allocation.cpp

--- a/test/source/allocation.cpp
+++ b/test/source/allocation.cpp
@@ -11,14 +11,13 @@
 auto const& get_one(smeagle::Corpus const& corpus, char const* name) {
   auto const& funcs = corpus.getFunctions();
 
-  return *std::find_if(funcs.begin(), funcs.end(),
-					 [name](smeagle::abi_description const& d) {
-					   return d.function_name == name;
-					 });
+  return *std::find_if(funcs.begin(), funcs.end(), [name](smeagle::abi_description const& d) {
+    return d.function_name == name;
+  });
 }
 
 namespace {
-	auto corpus = smeagle::Smeagle("liballocation.so").parse();
+  auto corpus = smeagle::Smeagle("liballocation.so").parse();
 }
 
 TEST_CASE("Register Allocation - Integral Types") {

--- a/test/source/libs/allocation.cpp
+++ b/test/source/libs/allocation.cpp
@@ -1,80 +1,80 @@
 // Functions to test register allocation
 
-#include <iostream>
 #include <complex.h>
 
+#include <iostream>
 
 // Integral Types
-extern "C" void test_bool(bool x){}
-extern "C" void test_char(char x){}
-extern "C" void test_short(short x){}
-extern "C" void test_int(int x){}
-extern "C" void test_long(long x){}
-extern "C" void test_long_long(long long x){}
+extern "C" void test_bool(bool x) {}
+extern "C" void test_char(char x) {}
+extern "C" void test_short(short x) {}
+extern "C" void test_int(int x) {}
+extern "C" void test_long(long x) {}
+extern "C" void test_long_long(long long x) {}
 
 // Signed Integral Types
-extern "C" void test_signed(signed x){}
-extern "C" void test_signed_char(signed char x){}
-extern "C" void test_signed_short(signed short x){}
-extern "C" void test_signed_int(signed int x){}
-extern "C" void test_signed_long(signed long x){}
-extern "C" void test_signed_long_long(signed long long x){}
+extern "C" void test_signed(signed x) {}
+extern "C" void test_signed_char(signed char x) {}
+extern "C" void test_signed_short(signed short x) {}
+extern "C" void test_signed_int(signed int x) {}
+extern "C" void test_signed_long(signed long x) {}
+extern "C" void test_signed_long_long(signed long long x) {}
 
 // Unigned Integral Types
-extern "C" void test_unsigned(unsigned x){}
-extern "C" void test_unsigned_char(unsigned char x){}
-extern "C" void test_unsigned_short(unsigned short x){}
-extern "C" void test_unsigned_int(unsigned int x){}
-extern "C" void test_unsigned_long(unsigned long x){}
-extern "C" void test_unsigned_long_long(unsigned long long x){}
+extern "C" void test_unsigned(unsigned x) {}
+extern "C" void test_unsigned_char(unsigned char x) {}
+extern "C" void test_unsigned_short(unsigned short x) {}
+extern "C" void test_unsigned_int(unsigned int x) {}
+extern "C" void test_unsigned_long(unsigned long x) {}
+extern "C" void test_unsigned_long_long(unsigned long long x) {}
 
 // Floating Point Types
-extern "C" void test_float(float x){}
-extern "C" void test_double(double x){}
-extern "C" void test_long_double(long double x){}
-extern "C" void test_float__Complex(float _Complex x){}
-extern "C" void test_double__Complex(double _Complex x){}
-extern "C" void test_long_double__Complex(long double _Complex x){}
+extern "C" void test_float(float x) {}
+extern "C" void test_double(double x) {}
+extern "C" void test_long_double(long double x) {}
+extern "C" void test_float__Complex(float _Complex x) {}
+extern "C" void test_double__Complex(double _Complex x) {}
+extern "C" void test_long_double__Complex(long double _Complex x) {}
 
 // Size Types
-extern "C" void test_wchar_t(wchar_t x){}
-extern "C" void test_char16_t(char16_t x){}
-extern "C" void test_char32_t(char32_t x){}
+extern "C" void test_wchar_t(wchar_t x) {}
+extern "C" void test_char16_t(char16_t x) {}
+extern "C" void test_char32_t(char32_t x) {}
 
 // Size Types
-extern "C" void test_size_t(size_t x){}
-extern "C" void test_intmax_t(intmax_t x){}
-extern "C" void test_uintmax_t(uintmax_t x){}
-extern "C" void test_intptr_t(intptr_t x){}
-extern "C" void test_uintptr_t(uintptr_t x){}
+extern "C" void test_size_t(size_t x) {}
+extern "C" void test_intmax_t(intmax_t x) {}
+extern "C" void test_uintmax_t(uintmax_t x) {}
+extern "C" void test_intptr_t(intptr_t x) {}
+extern "C" void test_uintptr_t(uintptr_t x) {}
 
 // Fixed-width Integral Types
-extern "C" void test_int8_t(int8_t x){}
-extern "C" void test_int16_t(int16_t x){}
-extern "C" void test_int32_t(int32_t x){}
-extern "C" void test_int64_t(int64_t x){}
-extern "C" void test_int_fast8_t(int_fast8_t x){}
-extern "C" void test_int_fast16_t(int_fast16_t x){}
-extern "C" void test_int_fast32_t(int_fast32_t x){}
-extern "C" void test_int_fast64_t(int_fast64_t x){}
-extern "C" void test_int_least8_t(int_least8_t x){}
-extern "C" void test_int_least16_t(int_least16_t x){}
-extern "C" void test_int_least32_t(int_least32_t x){}
-extern "C" void test_int_least64_t(int_least64_t x){}
+extern "C" void test_int8_t(int8_t x) {}
+extern "C" void test_int16_t(int16_t x) {}
+extern "C" void test_int32_t(int32_t x) {}
+extern "C" void test_int64_t(int64_t x) {}
+extern "C" void test_int_fast8_t(int_fast8_t x) {}
+extern "C" void test_int_fast16_t(int_fast16_t x) {}
+extern "C" void test_int_fast32_t(int_fast32_t x) {}
+extern "C" void test_int_fast64_t(int_fast64_t x) {}
+extern "C" void test_int_least8_t(int_least8_t x) {}
+extern "C" void test_int_least16_t(int_least16_t x) {}
+extern "C" void test_int_least32_t(int_least32_t x) {}
+extern "C" void test_int_least64_t(int_least64_t x) {}
 
 // Unsigned Fixed-width Integral Types
-extern "C" void test_uint8_t(uint8_t x){}
-extern "C" void test_uint16_t(uint16_t x){}
-extern "C" void test_uint32_t(uint32_t x){}
-extern "C" void test_uint64_t(uint64_t x){}
-extern "C" void test_uint_fast8_t(uint_fast8_t x){}
-extern "C" void test_uint_fast16_t(uint_fast16_t x){}
-extern "C" void test_uint_fast32_t(uint_fast32_t x){}
-extern "C" void test_uint_fast64_t(uint_fast64_t x){}
-extern "C" void test_uint_least8_t(uint_least8_t x){}
-extern "C" void test_uint_least16_t(uint_least16_t x){}
-extern "C" void test_uint_least32_t(uint_least32_t x){}
-extern "C" void test_uint_least64_t(uint_least64_t x){}
+extern "C" void test_uint8_t(uint8_t x) {}
+extern "C" void test_uint16_t(uint16_t x) {}
+extern "C" void test_uint32_t(uint32_t x) {}
+extern "C" void test_uint64_t(uint64_t x) {}
+extern "C" void test_uint_fast8_t(uint_fast8_t x) {}
+extern "C" void test_uint_fast16_t(uint_fast16_t x) {}
+extern "C" void test_uint_fast32_t(uint_fast32_t x) {}
+extern "C" void test_uint_fast64_t(uint_fast64_t x) {}
+extern "C" void test_uint_least8_t(uint_least8_t x) {}
+extern "C" void test_uint_least16_t(uint_least16_t x) {}
+extern "C" void test_uint_least32_t(uint_least32_t x) {}
+extern "C" void test_uint_least64_t(uint_least64_t x) {}
 
 // Register Allocation - Null Type
-extern "C" void test_void(){}
+extern "C" void test_void() {}


### PR DESCRIPTION
This will fix a bug in the generated yaml that values need to be quoted (to avoid invalid characters without said quotes).

I also ran formatting which explains the other tweaks to files.

Signed-off-by: vsoch <vsoch@users.noreply.github.com>