### PR TITLE
Adding correct quoting and endline to asp output

### DIFF
--- a/source/corpora.cpp
+++ b/source/corpora.cpp
@@ -23,8 +23,9 @@ void Corpus::toAsp() {
   for (auto &f : functions) {
     for (auto const &p : f.parameters) {
       std::cout << "abi_typelocation("
-                << "\"" << library << "\", " << f.function_name << ", " << p.name << ", " << p.type
-                << ", \"" << p.location << "\", " << p.direction << ")" << std::endl;
+                << "\"" << library << "\", \"" << f.function_name << "\", \"" << p.name << "\", \""
+                << p.type << "\", \"" << p.location << "\", \"" << p.direction << "\")."
+                << std::endl;
     }
   }
 }


### PR DESCRIPTION
I started writing some asp this morning and realized we are missing quotes for the asp too AND the ending period! /bonk. This PR will update output to have that, e.g.,:

```
abi_typelocation("libtcl8.6.so", "Tcl_AsyncInvoke", "code", "Integer32", "%rsi", "import").
abi_typelocation("libtcl8.6.so", "Tcl_AppendResult", "interp", "", "%rdi", "unknown").
abi_typelocation("libtcl8.6.so", "TclBN_mp_set_int", "a", "", "%rdi", "unknown").
abi_typelocation("libtcl8.6.so", "TclBN_mp_set_int", "i", "Integer64", "%rsi", "import").
abi_typelocation("libtcl8.6.so", "Tcl_DeleteHashEntry", "entryPtr", "", "%rdi", "unknown").
```
Signed-off-by: vsoch <vsoch@users.noreply.github.com>