### PR TITLE
removing extra symtabAPI variable from CMakeLists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
 .PHONY: all test standalone docs
 
 all:
-	cmake --log-level=VERBOSE -DsymtabAPI_DIR=/opt/view/lib/cmake/Dyninst -S all -B build
-	cmake --build build -DsymtabAPI_DIR=/opt/view/lib/cmake/Dyninst
+	cmake --log-level=VERBOSE -S all -B build
+	cmake --build build
 
 
 test:
-	cmake -S test -B build/test -DsymtabAPI_DIR=/opt/view/lib/cmake/Dyninst
+	cmake -S test -B build/test
 	cmake --build build/test
 	CTEST_OUTPUT_ON_FAILURE=1 cmake --build build/test --target test
 


### PR DESCRIPTION
This will address #37. I'm not sure why / how it works to know where Dyninst is (it must be @hainest magic)  but we indeed aren't using the symbol! It must be that find_package works really well!

Signed-off-by: vsoch <vsoch@users.noreply.github.com>