### PR TITLE
Add manual TBB CMake package inclusion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ include(cmake/CPM.cmake)
 
 find_package(Dyninst REQUIRED)
 find_package(Boost REQUIRED)
+find_package(TBB REQUIRED)
 
 # PackageProject.cmake will be used to make our target installable
 CPMAddPackage("gh:TheLartians/PackageProject.cmake@1.6.0")
@@ -47,7 +48,7 @@ add_library(Smeagle ${sources})
 set_target_properties(Smeagle PROPERTIES CXX_STANDARD 17)
 
 # Link dependencies
-target_link_libraries(Smeagle PRIVATE fmt::fmt Boost::boost common symtabAPI)
+target_link_libraries(Smeagle PUBLIC fmt::fmt Boost::boost TBB::tbb common symtabAPI)
 
 target_include_directories(
   Smeagle


### PR DESCRIPTION
This works in the container without modification because TBB is in the default PATH. If ever I get the time, I will update Dyninst's build system so that it correctly exports its dependencies and this will no longer be necessary. Note that these dependencies are made part of the 'Smeagle' target's public interface because they also need to be consumed by anything that links against it (e.g., our tests).