### PR TITLE
Separate type names from their sizes

### DIFF
--- a/include/smeagle/parameter.h
+++ b/include/smeagle/parameter.h
@@ -22,6 +22,7 @@ namespace smeagle {
     std::string direction;
     int pointer_indirections;
     std::string location;
+    size_t size_in_bytes;
   };
 
 }  // namespace smeagle

--- a/source/corpora.cpp
+++ b/source/corpora.cpp
@@ -57,6 +57,7 @@ void Corpus::toJson() {
                 << "\"type\":\"" << p.type << "\", "
                 << "\"location\":\"" << p.location << "\", " << pointer_indirections
                 << "\"direction\":\"" << p.direction << "\""
+				<< "\"size\":\"" << p.size_in_bytes << "\""
                 << "}" << endcomma << '\n';
     }
     std::cout << "    ]\n"

--- a/source/parser/x86_64/classifiers.hpp
+++ b/source/parser/x86_64/classifiers.hpp
@@ -41,7 +41,7 @@ namespace smeagle::x86_64 {
        *
        */
       // TODO Should we integrate the directionality calculation here?
-      return {RegisterClass::INTEGER, RegisterClass::NO_CLASS, ptr_cnt, "Pointer64"};
+      return {RegisterClass::INTEGER, RegisterClass::NO_CLASS, ptr_cnt, "Pointer"};
     }
 
     // paramType properties have booleans to indicate types
@@ -50,45 +50,41 @@ namespace smeagle::x86_64 {
     // Integral types
     if (props.is_integral || props.is_UTF) {
       if (size > 128) {
-        return {RegisterClass::SSE, RegisterClass::SSEUP, ptr_cnt,
-                "IntegerVec" + std::to_string(size)};
+        return {RegisterClass::SSE, RegisterClass::SSEUP, ptr_cnt, "IntegerVec"};
       }
       if (size == 128) {
         // __int128 is treated as struct{long,long};
         // This is NOT correct, but we don't handle aggregates yet.
         // How do we differentiate between __int128 and __m128i?
-        return {RegisterClass::MEMORY, RegisterClass::NO_CLASS, ptr_cnt, "Integer128"};
+        return {RegisterClass::MEMORY, RegisterClass::NO_CLASS, ptr_cnt, "Integer"};
       }
 
       // _Decimal32, _Decimal64, and __m64 are supposed to be SSE.
       // TODO How can we differentiate them here?
-      return {RegisterClass::INTEGER, RegisterClass::NO_CLASS, ptr_cnt,
-              "Integer" + std::to_string(size)};
+      return {RegisterClass::INTEGER, RegisterClass::NO_CLASS, ptr_cnt, "Integer"};
     }
 
     if (props.is_floating_point) {
       if (props.is_complex_float) {
         if (size == 128) {
           // x87 `complex long double`
-          return {RegisterClass::COMPLEX_X87, RegisterClass::NO_CLASS, ptr_cnt, "CplxFloat128"};
+          return {RegisterClass::COMPLEX_X87, RegisterClass::NO_CLASS, ptr_cnt, "CplxFloat"};
         }
         // This is NOT correct.
         // TODO It should be struct{T r,i;};, but we don't handle aggregates yet
-        return {RegisterClass::MEMORY, RegisterClass::NO_CLASS, ptr_cnt,
-                "CplxFloat" + std::to_string(size / 2)};
+        return {RegisterClass::MEMORY, RegisterClass::NO_CLASS, ptr_cnt, "CplxFloat"};
       }
       if (size <= 64) {
         // 32- or 64-bit floats
-        return {RegisterClass::SSE, RegisterClass::SSEUP, ptr_cnt, "Float" + std::to_string(size)};
+        return {RegisterClass::SSE, RegisterClass::SSEUP, ptr_cnt, "Float"};
       }
       if (size == 128) {
         // x87 `long double` OR __m128[d]
-        // TODO: How do we differntiate the vector type here? Dyninst should help us
-        return {RegisterClass::X87, RegisterClass::X87UP, ptr_cnt, "Float128"};
+        // TODO: How do we differentiate the vector type here? Dyninst should help us
+        return {RegisterClass::X87, RegisterClass::X87UP, ptr_cnt, "Float"};
       }
       if (size > 128) {
-        return {RegisterClass::SSE, RegisterClass::SSEUP, ptr_cnt,
-                "FloatVec" + std::to_string(size)};
+        return {RegisterClass::SSE, RegisterClass::SSEUP, ptr_cnt, "FloatVec"};
       }
     }
 

--- a/source/parser/x86_64/x86_64.cpp
+++ b/source/parser/x86_64/x86_64.cpp
@@ -99,6 +99,7 @@ namespace smeagle::x86_64 {
         p.pointer_indirections = c.pointer_indirections;
         p.location = allocator.getRegisterString(c.lo, c.hi, paramType);
         p.direction = direction;
+        p.size_in_bytes = paramType->getSize();
         typelocs.push_back(p);
       }
     }

--- a/test/source/allocation.cpp
+++ b/test/source/allocation.cpp
@@ -26,120 +26,120 @@ TEST_CASE("Register Allocation - Integral Types") {
     auto func = get_one(corpus, "test_bool");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Integer8");
+    CHECK(parameters[0].type == "Integer");
   }
   SUBCASE("bool*") {
     auto func = get_one(corpus, "test_ptr_bool");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 1);
   }
   SUBCASE("bool**") {
     auto func = get_one(corpus, "test_ptr_ptr_bool");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 2);
   }
   SUBCASE("char") {
     auto func = get_one(corpus, "test_char");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Integer8");
+    CHECK(parameters[0].type == "Integer");
   }
   SUBCASE("char*") {
     auto func = get_one(corpus, "test_ptr_char");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 1);
   }
   SUBCASE("char**") {
     auto func = get_one(corpus, "test_ptr_ptr_char");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 2);
   }
   SUBCASE("short") {
     auto func = get_one(corpus, "test_short");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Integer16");
+    CHECK(parameters[0].type == "Integer");
   }
   SUBCASE("short*") {
     auto func = get_one(corpus, "test_ptr_short");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 1);
   }
   SUBCASE("short**") {
     auto func = get_one(corpus, "test_ptr_ptr_short");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 2);
   }
   SUBCASE("int") {
     auto func = get_one(corpus, "test_int");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Integer32");
+    CHECK(parameters[0].type == "Integer");
   }
   SUBCASE("int*") {
     auto func = get_one(corpus, "test_ptr_int");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 1);
   }
   SUBCASE("int**") {
     auto func = get_one(corpus, "test_ptr_ptr_int");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 2);
   }
   SUBCASE("long") {
     auto func = get_one(corpus, "test_long");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Integer64");
+    CHECK(parameters[0].type == "Integer");
   }
   SUBCASE("long*") {
     auto func = get_one(corpus, "test_ptr_long");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 1);
   }
   SUBCASE("long**") {
     auto func = get_one(corpus, "test_ptr_ptr_long");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 2);
   }
   SUBCASE("long long") {
     auto func = get_one(corpus, "test_long_long");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Integer64");
+    CHECK(parameters[0].type == "Integer");
   }
   SUBCASE("long long*") {
     auto func = get_one(corpus, "test_ptr_long_long");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 1);
   }
   SUBCASE("long long**") {
     auto func = get_one(corpus, "test_ptr_ptr_long_long");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 2);
   }
 }
@@ -148,120 +148,120 @@ TEST_CASE("Register Allocation - Signed Integral Types") {
     auto func = get_one(corpus, "test_signed");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Integer32");
+    CHECK(parameters[0].type == "Integer");
   }
   SUBCASE("signed*") {
     auto func = get_one(corpus, "test_ptr_signed");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 1);
   }
   SUBCASE("signed**") {
     auto func = get_one(corpus, "test_ptr_ptr_signed");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 2);
   }
   SUBCASE("signed char") {
     auto func = get_one(corpus, "test_signed_char");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Integer8");
+    CHECK(parameters[0].type == "Integer");
   }
   SUBCASE("signed char*") {
     auto func = get_one(corpus, "test_ptr_signed_char");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 1);
   }
   SUBCASE("signed char**") {
     auto func = get_one(corpus, "test_ptr_ptr_signed_char");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 2);
   }
   SUBCASE("signed short") {
     auto func = get_one(corpus, "test_signed_short");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Integer16");
+    CHECK(parameters[0].type == "Integer");
   }
   SUBCASE("signed short*") {
     auto func = get_one(corpus, "test_ptr_signed_short");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 1);
   }
   SUBCASE("signed short**") {
     auto func = get_one(corpus, "test_ptr_ptr_signed_short");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 2);
   }
   SUBCASE("signed int") {
     auto func = get_one(corpus, "test_signed_int");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Integer32");
+    CHECK(parameters[0].type == "Integer");
   }
   SUBCASE("signed int*") {
     auto func = get_one(corpus, "test_ptr_signed_int");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 1);
   }
   SUBCASE("signed int**") {
     auto func = get_one(corpus, "test_ptr_ptr_signed_int");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 2);
   }
   SUBCASE("signed long") {
     auto func = get_one(corpus, "test_signed_long");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Integer64");
+    CHECK(parameters[0].type == "Integer");
   }
   SUBCASE("signed long*") {
     auto func = get_one(corpus, "test_ptr_signed_long");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 1);
   }
   SUBCASE("signed long**") {
     auto func = get_one(corpus, "test_ptr_ptr_signed_long");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 2);
   }
   SUBCASE("signed long long") {
     auto func = get_one(corpus, "test_signed_long_long");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Integer64");
+    CHECK(parameters[0].type == "Integer");
   }
   SUBCASE("signed long long*") {
     auto func = get_one(corpus, "test_ptr_signed_long_long");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 1);
   }
   SUBCASE("signed long long**") {
     auto func = get_one(corpus, "test_ptr_ptr_signed_long_long");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 2);
   }
 }
@@ -270,120 +270,120 @@ TEST_CASE("Register Allocation - Unsigned Integral Types") {
     auto func = get_one(corpus, "test_unsigned");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Integer32");
+    CHECK(parameters[0].type == "Integer");
   }
   SUBCASE("unsigned*") {
     auto func = get_one(corpus, "test_ptr_unsigned");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 1);
   }
   SUBCASE("unsigned**") {
     auto func = get_one(corpus, "test_ptr_ptr_unsigned");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 2);
   }
   SUBCASE("unsigned char") {
     auto func = get_one(corpus, "test_unsigned_char");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Integer8");
+    CHECK(parameters[0].type == "Integer");
   }
   SUBCASE("unsigned char*") {
     auto func = get_one(corpus, "test_ptr_unsigned_char");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 1);
   }
   SUBCASE("unsigned char**") {
     auto func = get_one(corpus, "test_ptr_ptr_unsigned_char");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 2);
   }
   SUBCASE("unsigned short") {
     auto func = get_one(corpus, "test_unsigned_short");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Integer16");
+    CHECK(parameters[0].type == "Integer");
   }
   SUBCASE("unsigned short*") {
     auto func = get_one(corpus, "test_ptr_unsigned_short");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 1);
   }
   SUBCASE("unsigned short**") {
     auto func = get_one(corpus, "test_ptr_ptr_unsigned_short");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 2);
   }
   SUBCASE("unsigned int") {
     auto func = get_one(corpus, "test_unsigned_int");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Integer32");
+    CHECK(parameters[0].type == "Integer");
   }
   SUBCASE("unsigned int*") {
     auto func = get_one(corpus, "test_ptr_unsigned_int");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 1);
   }
   SUBCASE("unsigned int**") {
     auto func = get_one(corpus, "test_ptr_ptr_unsigned_int");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 2);
   }
   SUBCASE("unsigned long") {
     auto func = get_one(corpus, "test_unsigned_long");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Integer64");
+    CHECK(parameters[0].type == "Integer");
   }
   SUBCASE("unsigned long*") {
     auto func = get_one(corpus, "test_ptr_unsigned_long");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 1);
   }
   SUBCASE("unsigned long**") {
     auto func = get_one(corpus, "test_ptr_ptr_unsigned_long");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 2);
   }
   SUBCASE("unsigned long long") {
     auto func = get_one(corpus, "test_unsigned_long_long");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Integer64");
+    CHECK(parameters[0].type == "Integer");
   }
   SUBCASE("unsigned long long*") {
     auto func = get_one(corpus, "test_ptr_unsigned_long_long");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 1);
   }
   SUBCASE("unsigned long long**") {
     auto func = get_one(corpus, "test_ptr_ptr_unsigned_long_long");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 2);
   }
 }
@@ -392,120 +392,120 @@ TEST_CASE("Register Allocation - Floating Point Types") {
     auto func = get_one(corpus, "test_float");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%xmm0");
-    CHECK(parameters[0].type == "Float32");
+    CHECK(parameters[0].type == "Float");
   }
   SUBCASE("float*") {
     auto func = get_one(corpus, "test_ptr_float");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 1);
   }
   SUBCASE("float**") {
     auto func = get_one(corpus, "test_ptr_ptr_float");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 2);
   }
   SUBCASE("double") {
     auto func = get_one(corpus, "test_double");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%xmm0");
-    CHECK(parameters[0].type == "Float64");
+    CHECK(parameters[0].type == "Float");
   }
   SUBCASE("double*") {
     auto func = get_one(corpus, "test_ptr_double");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 1);
   }
   SUBCASE("double**") {
     auto func = get_one(corpus, "test_ptr_ptr_double");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 2);
   }
   SUBCASE("long double") {
     auto func = get_one(corpus, "test_long_double");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "framebase+8");
-    CHECK(parameters[0].type == "Float128");
+    CHECK(parameters[0].type == "Float");
   }
   SUBCASE("long double*") {
     auto func = get_one(corpus, "test_ptr_long_double");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 1);
   }
   SUBCASE("long double**") {
     auto func = get_one(corpus, "test_ptr_ptr_long_double");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 2);
   }
   SUBCASE("float _Complex") {
     auto func = get_one(corpus, "test_float__Complex");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "framebase+8");
-    CHECK(parameters[0].type == "CplxFloat32");
+    CHECK(parameters[0].type == "CplxFloat");
   }
   SUBCASE("float _Complex*") {
     auto func = get_one(corpus, "test_ptr_float__Complex");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 1);
   }
   SUBCASE("float _Complex**") {
     auto func = get_one(corpus, "test_ptr_ptr_float__Complex");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 2);
   }
   SUBCASE("double _Complex") {
     auto func = get_one(corpus, "test_double__Complex");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "framebase+8");
-    CHECK(parameters[0].type == "CplxFloat128");
+    CHECK(parameters[0].type == "CplxFloat");
   }
   SUBCASE("double _Complex*") {
     auto func = get_one(corpus, "test_ptr_double__Complex");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 1);
   }
   SUBCASE("double _Complex**") {
     auto func = get_one(corpus, "test_ptr_ptr_double__Complex");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 2);
   }
   SUBCASE("long double _Complex") {
     auto func = get_one(corpus, "test_long_double__Complex");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "framebase+8");
-    CHECK(parameters[0].type == "CplxFloat128");
+    CHECK(parameters[0].type == "CplxFloat");
   }
   SUBCASE("long double _Complex*") {
     auto func = get_one(corpus, "test_ptr_long_double__Complex");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 1);
   }
   SUBCASE("long double _Complex**") {
     auto func = get_one(corpus, "test_ptr_ptr_long_double__Complex");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 2);
   }
 }
@@ -514,60 +514,60 @@ TEST_CASE("Register Allocation - UTF Types") {
     auto func = get_one(corpus, "test_wchar_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Integer32");
+    CHECK(parameters[0].type == "Integer");
   }
   SUBCASE("wchar_t*") {
     auto func = get_one(corpus, "test_ptr_wchar_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 1);
   }
   SUBCASE("wchar_t**") {
     auto func = get_one(corpus, "test_ptr_ptr_wchar_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 2);
   }
   SUBCASE("char16_t") {
     auto func = get_one(corpus, "test_char16_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Integer16");
+    CHECK(parameters[0].type == "Integer");
   }
   SUBCASE("char16_t*") {
     auto func = get_one(corpus, "test_ptr_char16_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 1);
   }
   SUBCASE("char16_t**") {
     auto func = get_one(corpus, "test_ptr_ptr_char16_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 2);
   }
   SUBCASE("char32_t") {
     auto func = get_one(corpus, "test_char32_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Integer32");
+    CHECK(parameters[0].type == "Integer");
   }
   SUBCASE("char32_t*") {
     auto func = get_one(corpus, "test_ptr_char32_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 1);
   }
   SUBCASE("char32_t**") {
     auto func = get_one(corpus, "test_ptr_ptr_char32_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 2);
   }
 }
@@ -576,100 +576,100 @@ TEST_CASE("Register Allocation - Size Types") {
     auto func = get_one(corpus, "test_size_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Integer64");
+    CHECK(parameters[0].type == "Integer");
   }
   SUBCASE("size_t*") {
     auto func = get_one(corpus, "test_ptr_size_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 1);
   }
   SUBCASE("size_t**") {
     auto func = get_one(corpus, "test_ptr_ptr_size_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 2);
   }
   SUBCASE("intmax_t") {
     auto func = get_one(corpus, "test_intmax_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Integer64");
+    CHECK(parameters[0].type == "Integer");
   }
   SUBCASE("intmax_t*") {
     auto func = get_one(corpus, "test_ptr_intmax_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 1);
   }
   SUBCASE("intmax_t**") {
     auto func = get_one(corpus, "test_ptr_ptr_intmax_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 2);
   }
   SUBCASE("uintmax_t") {
     auto func = get_one(corpus, "test_uintmax_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Integer64");
+    CHECK(parameters[0].type == "Integer");
   }
   SUBCASE("uintmax_t*") {
     auto func = get_one(corpus, "test_ptr_uintmax_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 1);
   }
   SUBCASE("uintmax_t**") {
     auto func = get_one(corpus, "test_ptr_ptr_uintmax_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 2);
   }
   SUBCASE("intptr_t") {
     auto func = get_one(corpus, "test_intptr_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Integer64");
+    CHECK(parameters[0].type == "Integer");
   }
   SUBCASE("intptr_t*") {
     auto func = get_one(corpus, "test_ptr_intptr_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 1);
   }
   SUBCASE("intptr_t**") {
     auto func = get_one(corpus, "test_ptr_ptr_intptr_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 2);
   }
   SUBCASE("uintptr_t") {
     auto func = get_one(corpus, "test_uintptr_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Integer64");
+    CHECK(parameters[0].type == "Integer");
   }
   SUBCASE("uintptr_t*") {
     auto func = get_one(corpus, "test_ptr_uintptr_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 1);
   }
   SUBCASE("uintptr_t**") {
     auto func = get_one(corpus, "test_ptr_ptr_uintptr_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 2);
   }
 }
@@ -678,228 +678,240 @@ TEST_CASE("Register Allocation - Fixed-width Integral Types") {
     auto func = get_one(corpus, "test_int8_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
+    CHECK(parameters[0].type == "Integer");
   }
   SUBCASE("int8_t*") {
     auto func = get_one(corpus, "test_ptr_int8_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 1);
   }
   SUBCASE("int8_t**") {
     auto func = get_one(corpus, "test_ptr_ptr_int8_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 2);
   }
   SUBCASE("int16_t") {
     auto func = get_one(corpus, "test_int16_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
+    CHECK(parameters[0].type == "Integer");
   }
   SUBCASE("int16_t*") {
     auto func = get_one(corpus, "test_ptr_int16_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 1);
   }
   SUBCASE("int16_t**") {
     auto func = get_one(corpus, "test_ptr_ptr_int16_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 2);
   }
   SUBCASE("int32_t") {
     auto func = get_one(corpus, "test_int32_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
+    CHECK(parameters[0].type == "Integer");
   }
   SUBCASE("int32_t*") {
     auto func = get_one(corpus, "test_ptr_int32_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 1);
   }
   SUBCASE("int32_t**") {
     auto func = get_one(corpus, "test_ptr_ptr_int32_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 2);
   }
   SUBCASE("int64_t") {
     auto func = get_one(corpus, "test_int64_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
+    CHECK(parameters[0].type == "Integer");
   }
   SUBCASE("int64_t*") {
     auto func = get_one(corpus, "test_ptr_int64_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 1);
   }
   SUBCASE("int64_t**") {
     auto func = get_one(corpus, "test_ptr_ptr_int64_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 2);
   }
   SUBCASE("int_fast8_t") {
     auto func = get_one(corpus, "test_int_fast8_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
+    CHECK(parameters[0].type == "Integer");
   }
   SUBCASE("int_fast8_t*") {
     auto func = get_one(corpus, "test_ptr_int_fast8_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 1);
   }
   SUBCASE("int_fast8_t**") {
     auto func = get_one(corpus, "test_ptr_ptr_int_fast8_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 2);
   }
   SUBCASE("int_fast16_t") {
     auto func = get_one(corpus, "test_int_fast16_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
+    CHECK(parameters[0].type == "Integer");
   }
   SUBCASE("int_fast16_t*") {
     auto func = get_one(corpus, "test_ptr_int_fast16_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 1);
   }
   SUBCASE("int_fast16_t**") {
     auto func = get_one(corpus, "test_ptr_ptr_int_fast16_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 2);
   }
   SUBCASE("int_fast32_t") {
     auto func = get_one(corpus, "test_int_fast32_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
+    CHECK(parameters[0].type == "Integer");
   }
   SUBCASE("int_fast32_t*") {
     auto func = get_one(corpus, "test_ptr_int_fast32_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 1);
   }
   SUBCASE("int_fast32_t**") {
     auto func = get_one(corpus, "test_ptr_ptr_int_fast32_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 2);
   }
   SUBCASE("int_fast64_t") {
     auto func = get_one(corpus, "test_int_fast64_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
+    CHECK(parameters[0].type == "Integer");
   }
   SUBCASE("int_fast64_t*") {
     auto func = get_one(corpus, "test_ptr_int_fast64_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 1);
   }
   SUBCASE("int_fast64_t**") {
     auto func = get_one(corpus, "test_ptr_ptr_int_fast64_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 2);
   }
   SUBCASE("int_least8_t") {
     auto func = get_one(corpus, "test_int_least8_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
+    CHECK(parameters[0].type == "Integer");
   }
   SUBCASE("int_least8_t*") {
     auto func = get_one(corpus, "test_ptr_int_least8_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 1);
   }
   SUBCASE("int_least8_t**") {
     auto func = get_one(corpus, "test_ptr_ptr_int_least8_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 2);
   }
   SUBCASE("int_least16_t") {
     auto func = get_one(corpus, "test_int_least16_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
+    CHECK(parameters[0].type == "Integer");
   }
   SUBCASE("int_least16_t*") {
     auto func = get_one(corpus, "test_ptr_int_least16_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 1);
   }
   SUBCASE("int_least16_t**") {
     auto func = get_one(corpus, "test_ptr_ptr_int_least16_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 2);
   }
   SUBCASE("int_least32_t") {
     auto func = get_one(corpus, "test_int_least32_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
+    CHECK(parameters[0].type == "Integer");
   }
   SUBCASE("int_least32_t*") {
     auto func = get_one(corpus, "test_ptr_int_least32_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 1);
   }
   SUBCASE("int_least32_t**") {
     auto func = get_one(corpus, "test_ptr_ptr_int_least32_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 2);
   }
   SUBCASE("int_least64_t") {
     auto func = get_one(corpus, "test_int_least64_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
+    CHECK(parameters[0].type == "Integer");
   }
   SUBCASE("int_least64_t*") {
     auto func = get_one(corpus, "test_ptr_int_least64_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 1);
   }
   SUBCASE("int_least64_t**") {
     auto func = get_one(corpus, "test_ptr_ptr_int_least64_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 2);
   }
 }
@@ -908,228 +920,240 @@ TEST_CASE("Register Allocation - Unsigned Fixed-width Integral Types") {
     auto func = get_one(corpus, "test_uint8_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
+    CHECK(parameters[0].type == "Integer");
   }
   SUBCASE("uint8_t*") {
     auto func = get_one(corpus, "test_ptr_uint8_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 1);
   }
   SUBCASE("uint8_t**") {
     auto func = get_one(corpus, "test_ptr_ptr_uint8_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 2);
   }
   SUBCASE("uint16_t") {
     auto func = get_one(corpus, "test_uint16_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
+    CHECK(parameters[0].type == "Integer");
   }
   SUBCASE("uint16_t*") {
     auto func = get_one(corpus, "test_ptr_uint16_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 1);
   }
   SUBCASE("uint16_t**") {
     auto func = get_one(corpus, "test_ptr_ptr_uint16_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 2);
   }
   SUBCASE("uint32_t") {
     auto func = get_one(corpus, "test_uint32_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
+    CHECK(parameters[0].type == "Integer");
   }
   SUBCASE("uint32_t*") {
     auto func = get_one(corpus, "test_ptr_uint32_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 1);
   }
   SUBCASE("uint32_t**") {
     auto func = get_one(corpus, "test_ptr_ptr_uint32_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 2);
   }
   SUBCASE("uint64_t") {
     auto func = get_one(corpus, "test_uint64_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
+    CHECK(parameters[0].type == "Integer");
   }
   SUBCASE("uint64_t*") {
     auto func = get_one(corpus, "test_ptr_uint64_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 1);
   }
   SUBCASE("uint64_t**") {
     auto func = get_one(corpus, "test_ptr_ptr_uint64_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 2);
   }
   SUBCASE("uint_fast8_t") {
     auto func = get_one(corpus, "test_uint_fast8_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
+    CHECK(parameters[0].type == "Integer");
   }
   SUBCASE("uint_fast8_t*") {
     auto func = get_one(corpus, "test_ptr_uint_fast8_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 1);
   }
   SUBCASE("uint_fast8_t**") {
     auto func = get_one(corpus, "test_ptr_ptr_uint_fast8_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 2);
   }
   SUBCASE("uint_fast16_t") {
     auto func = get_one(corpus, "test_uint_fast16_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
+    CHECK(parameters[0].type == "Integer");
   }
   SUBCASE("uint_fast16_t*") {
     auto func = get_one(corpus, "test_ptr_uint_fast16_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 1);
   }
   SUBCASE("uint_fast16_t**") {
     auto func = get_one(corpus, "test_ptr_ptr_uint_fast16_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 2);
   }
   SUBCASE("uint_fast32_t") {
     auto func = get_one(corpus, "test_uint_fast32_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
+    CHECK(parameters[0].type == "Integer");
   }
   SUBCASE("uint_fast32_t*") {
     auto func = get_one(corpus, "test_ptr_uint_fast32_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 1);
   }
   SUBCASE("uint_fast32_t**") {
     auto func = get_one(corpus, "test_ptr_ptr_uint_fast32_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 2);
   }
   SUBCASE("uint_fast64_t") {
     auto func = get_one(corpus, "test_uint_fast64_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
+    CHECK(parameters[0].type == "Integer");
   }
   SUBCASE("uint_fast64_t*") {
     auto func = get_one(corpus, "test_ptr_uint_fast64_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 1);
   }
   SUBCASE("uint_fast64_t**") {
     auto func = get_one(corpus, "test_ptr_ptr_uint_fast64_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 2);
   }
   SUBCASE("uint_least8_t") {
     auto func = get_one(corpus, "test_uint_least8_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
+    CHECK(parameters[0].type == "Integer");
   }
   SUBCASE("uint_least8_t*") {
     auto func = get_one(corpus, "test_ptr_uint_least8_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 1);
   }
   SUBCASE("uint_least8_t**") {
     auto func = get_one(corpus, "test_ptr_ptr_uint_least8_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 2);
   }
   SUBCASE("uint_least16_t") {
     auto func = get_one(corpus, "test_uint_least16_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
+    CHECK(parameters[0].type == "Integer");
   }
   SUBCASE("uint_least16_t*") {
     auto func = get_one(corpus, "test_ptr_uint_least16_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 1);
   }
   SUBCASE("uint_least16_t**") {
     auto func = get_one(corpus, "test_ptr_ptr_uint_least16_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 2);
   }
   SUBCASE("uint_least32_t") {
     auto func = get_one(corpus, "test_uint_least32_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
+    CHECK(parameters[0].type == "Integer");
   }
   SUBCASE("uint_least32_t*") {
     auto func = get_one(corpus, "test_ptr_uint_least32_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 1);
   }
   SUBCASE("uint_least32_t**") {
     auto func = get_one(corpus, "test_ptr_ptr_uint_least32_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 2);
   }
   SUBCASE("uint_least64_t") {
     auto func = get_one(corpus, "test_uint_least64_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
+    CHECK(parameters[0].type == "Integer");
   }
   SUBCASE("uint_least64_t*") {
     auto func = get_one(corpus, "test_ptr_uint_least64_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 1);
   }
   SUBCASE("uint_least64_t**") {
     auto func = get_one(corpus, "test_ptr_ptr_uint_least64_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
     CHECK(parameters[0].pointer_indirections == 2);
   }
 }
@@ -1144,12 +1168,12 @@ TEST_CASE("Register Allocation - Null Types") {
     auto const& func = get_one(corpus, "test_ptr_void");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
   }
   SUBCASE("void") {
     auto const& func = get_one(corpus, "test_ptr_ptr_void");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
   }
 }

--- a/test/source/libs/gen_allocation.py
+++ b/test/source/libs/gen_allocation.py
@@ -17,99 +17,97 @@ types = [
     {
         'category': "Integral Types",
         'types': [
-            {'name':'bool',      'type':'Integer8',  'res':'%rdi'},
-            {'name':'char',      'type':'Integer8',  'res':'%rdi'},
-            {'name':'short',     'type':'Integer16', 'res':'%rdi'},
-            {'name':'int',       'type':'Integer32', 'res':'%rdi'},
-            {'name':'long',      'type':'Integer64', 'res':'%rdi'},
-            {'name':'long long', 'type':'Integer64', 'res':'%rdi'}
+            {'name':'bool',      'type':'Integer',  'res':'%rdi'},
+            {'name':'char',      'type':'Integer',  'res':'%rdi'},
+            {'name':'short',     'type':'Integer', 'res':'%rdi'},
+            {'name':'int',       'type':'Integer', 'res':'%rdi'},
+            {'name':'long',      'type':'Integer', 'res':'%rdi'},
+            {'name':'long long', 'type':'Integer', 'res':'%rdi'}
         ]
     },
     {
         'category': "Signed Integral Types",
         'types': [
-            {'name':'signed',           'type':'Integer32', 'res':'%rdi'},
-            {'name':'signed char',      'type':'Integer8',  'res':'%rdi'},
-            {'name':'signed short',     'type':'Integer16', 'res':'%rdi'},
-            {'name':'signed int',       'type':'Integer32', 'res':'%rdi'},
-            {'name':'signed long',      'type':'Integer64', 'res':'%rdi'},
-            {'name':'signed long long', 'type':'Integer64', 'res':'%rdi'}
+            {'name':'signed',           'type':'Integer', 'res':'%rdi'},
+            {'name':'signed char',      'type':'Integer',  'res':'%rdi'},
+            {'name':'signed short',     'type':'Integer', 'res':'%rdi'},
+            {'name':'signed int',       'type':'Integer', 'res':'%rdi'},
+            {'name':'signed long',      'type':'Integer', 'res':'%rdi'},
+            {'name':'signed long long', 'type':'Integer', 'res':'%rdi'}
         ]
     },
     {
         'category': "Unsigned Integral Types",
         'types': [
-            {'name':'unsigned',           'type':'Integer32', 'res':'%rdi'},
-            {'name':'unsigned char',      'type':'Integer8',  'res':'%rdi'},
-            {'name':'unsigned short',     'type':'Integer16', 'res':'%rdi'},
-            {'name':'unsigned int',       'type':'Integer32', 'res':'%rdi'},
-            {'name':'unsigned long',      'type':'Integer64', 'res':'%rdi'},
-            {'name':'unsigned long long', 'type':'Integer64', 'res':'%rdi'}
+            {'name':'unsigned',           'type':'Integer', 'res':'%rdi'},
+            {'name':'unsigned char',      'type':'Integer',  'res':'%rdi'},
+            {'name':'unsigned short',     'type':'Integer', 'res':'%rdi'},
+            {'name':'unsigned int',       'type':'Integer', 'res':'%rdi'},
+            {'name':'unsigned long',      'type':'Integer', 'res':'%rdi'},
+            {'name':'unsigned long long', 'type':'Integer', 'res':'%rdi'}
         ]
     },
     {
         'category': "Floating Point Types",
         'types': [
-            {'name':'float',                'type':'Float32',      'res':'%xmm0'},
-            {'name':'double',               'type':'Float64',      'res':'%xmm0'},
-            {'name':'long double',          'type':'Float128',     'res':'framebase+8'},
-            {'name':'float _Complex',       'type':'CplxFloat32',  'res':'framebase+8'},
-            {'name':'double _Complex',      'type':'CplxFloat128', 'res':'framebase+8'},
-            {'name':'long double _Complex', 'type':'CplxFloat128', 'res':'framebase+8'}
+            {'name':'float',                'type':'Float',      'res':'%xmm0'},
+            {'name':'double',               'type':'Float',      'res':'%xmm0'},
+            {'name':'long double',          'type':'Float',     'res':'framebase+8'},
+            {'name':'float _Complex',       'type':'CplxFloat',  'res':'framebase+8'},
+            {'name':'double _Complex',      'type':'CplxFloat', 'res':'framebase+8'},
+            {'name':'long double _Complex', 'type':'CplxFloat', 'res':'framebase+8'}
         ]
     },
     {
         'category': "UTF Types",
         'types': [
-            {'name':'wchar_t',  'type':'Integer32', 'res':'%rdi'},
-            {'name':'char16_t', 'type':'Integer16', 'res':'%rdi'},
-            {'name':'char32_t', 'type':'Integer32', 'res':'%rdi'}
+            {'name':'wchar_t',  'type':'Integer', 'res':'%rdi'},
+            {'name':'char16_t', 'type':'Integer', 'res':'%rdi'},
+            {'name':'char32_t', 'type':'Integer', 'res':'%rdi'}
         ]
     },
     {
         'category': "Size Types",
         'types': [
-            {'name':'size_t',    'type':'Integer64', 'res':'%rdi'},
-            {'name':'intmax_t',  'type':'Integer64', 'res':'%rdi'},
-            {'name':'uintmax_t', 'type':'Integer64', 'res':'%rdi'},
-            {'name':'intptr_t',  'type':'Integer64', 'res':'%rdi'},
-            {'name':'uintptr_t', 'type':'Integer64', 'res':'%rdi'}
+            {'name':'size_t',    'type':'Integer', 'res':'%rdi'},
+            {'name':'intmax_t',  'type':'Integer', 'res':'%rdi'},
+            {'name':'uintmax_t', 'type':'Integer', 'res':'%rdi'},
+            {'name':'intptr_t',  'type':'Integer', 'res':'%rdi'},
+            {'name':'uintptr_t', 'type':'Integer', 'res':'%rdi'}
         ]
     },
     {
-        # Compilers are free to choose any size, so we don't try to test it here
         'category': "Fixed-width Integral Types",
         'types': [
-            {'name':'int8_t',        'res':'%rdi'},
-            {'name':'int16_t',       'res':'%rdi'},
-            {'name':'int32_t',       'res':'%rdi'},
-            {'name':'int64_t',       'res':'%rdi'},
-            {'name':'int_fast8_t',   'res':'%rdi'},
-            {'name':'int_fast16_t',  'res':'%rdi'},
-            {'name':'int_fast32_t',  'res':'%rdi'},
-            {'name':'int_fast64_t',  'res':'%rdi'},
-            {'name':'int_least8_t',  'res':'%rdi'},
-            {'name':'int_least16_t', 'res':'%rdi'},
-            {'name':'int_least32_t', 'res':'%rdi'},
-            {'name':'int_least64_t', 'res':'%rdi'}
+            {'name':'int8_t',        'type':'Integer', 'res':'%rdi'},
+            {'name':'int16_t',       'type':'Integer', 'res':'%rdi'},
+            {'name':'int32_t',       'type':'Integer', 'res':'%rdi'},
+            {'name':'int64_t',       'type':'Integer', 'res':'%rdi'},
+            {'name':'int_fast8_t',   'type':'Integer', 'res':'%rdi'},
+            {'name':'int_fast16_t',  'type':'Integer', 'res':'%rdi'},
+            {'name':'int_fast32_t',  'type':'Integer', 'res':'%rdi'},
+            {'name':'int_fast64_t',  'type':'Integer', 'res':'%rdi'},
+            {'name':'int_least8_t',  'type':'Integer', 'res':'%rdi'},
+            {'name':'int_least16_t', 'type':'Integer', 'res':'%rdi'},
+            {'name':'int_least32_t', 'type':'Integer', 'res':'%rdi'},
+            {'name':'int_least64_t', 'type':'Integer', 'res':'%rdi'}
         ]
     },
     {
-        # Compilers are free to choose any size, so we don't try to test it here
         'category': "Unsigned Fixed-width Integral Types",
         'types': [
-            {'name':'uint8_t',        'res':'%rdi'},
-            {'name':'uint16_t',       'res':'%rdi'},
-            {'name':'uint32_t',       'res':'%rdi'},
-            {'name':'uint64_t',       'res':'%rdi'},
-            {'name':'uint_fast8_t',   'res':'%rdi'},
-            {'name':'uint_fast16_t',  'res':'%rdi'},
-            {'name':'uint_fast32_t',  'res':'%rdi'},
-            {'name':'uint_fast64_t',  'res':'%rdi'},
-            {'name':'uint_least8_t',  'res':'%rdi'},
-            {'name':'uint_least16_t', 'res':'%rdi'},
-            {'name':'uint_least32_t', 'res':'%rdi'},
-            {'name':'uint_least64_t', 'res':'%rdi'}
+            {'name':'uint8_t',        'type':'Integer', 'res':'%rdi'},
+            {'name':'uint16_t',       'type':'Integer', 'res':'%rdi'},
+            {'name':'uint32_t',       'type':'Integer', 'res':'%rdi'},
+            {'name':'uint64_t',       'type':'Integer', 'res':'%rdi'},
+            {'name':'uint_fast8_t',   'type':'Integer', 'res':'%rdi'},
+            {'name':'uint_fast16_t',  'type':'Integer', 'res':'%rdi'},
+            {'name':'uint_fast32_t',  'type':'Integer', 'res':'%rdi'},
+            {'name':'uint_fast64_t',  'type':'Integer', 'res':'%rdi'},
+            {'name':'uint_least8_t',  'type':'Integer', 'res':'%rdi'},
+            {'name':'uint_least16_t', 'type':'Integer', 'res':'%rdi'},
+            {'name':'uint_least32_t', 'type':'Integer', 'res':'%rdi'},
+            {'name':'uint_least64_t', 'type':'Integer', 'res':'%rdi'}
         ]
     }
 ]
@@ -138,14 +136,13 @@ def make_tests(file, category, types):
         
         # Plain type test
         file.write(subcase.format(t['name'], name, t['res']))
-        if 'type' in t:
-            file.write('    CHECK(parameters[0].type == "{0}");\n'.format(t['type']))
+        file.write('    CHECK(parameters[0].type == "{0}");\n'.format(t['type']))
         file.write('  }')
         
         # Pointer indirection test
         for p in [['*', 'ptr_', 1], ['**','ptr_ptr_', 2]]:
             file.write(subcase.format(t['name']+p[0], p[1]+name, '%rdi'))
-            file.write('    CHECK(parameters[0].type == "Pointer64");\n')
+            file.write('    CHECK(parameters[0].type == "Pointer");\n')
             file.write('    CHECK(parameters[0].pointer_indirections == {0});\n'.format(p[2]))
             file.write('  }')
     
@@ -206,13 +203,13 @@ TEST_CASE("Register Allocation - Null Types") {
     auto const& func = get_one(corpus, "test_ptr_void");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
   }
   SUBCASE("void") {
     auto const& func = get_one(corpus, "test_ptr_ptr_void");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location == "%rdi");
-    CHECK(parameters[0].type == "Pointer64");
+    CHECK(parameters[0].type == "Pointer");
   }
 }
 """)


### PR DESCRIPTION
Some types do not have guaranteed sizes, so we split that information from the name.

Fixes #47