### PR TITLE
Move indirections to pointer type so not defined for all parameters

### DIFF
--- a/include/smeagle/parameter.h
+++ b/include/smeagle/parameter.h
@@ -19,17 +19,16 @@ namespace smeagle {
    */
   class parameter {
   public:
-    template <typename T> explicit parameter(T x) : self(std::make_shared<model<T>>(std::move(x))) {}
+    template <typename T>
+    explicit parameter(T x) : self(std::make_shared<model<T>>(std::move(x))) {}
 
     std::string name() const { return self->name(); }
     std::string type_name() const { return self->type_name(); }
     std::string class_name() const { return self->class_name(); }
     std::string direction() const { return self->direction(); }
     std::string location() const { return self->location(); }
-    int pointer_indirections() const { return self->pointer_indirections(); }
     size_t size_in_bytes() const { return self->size_in_bytes(); }
     void toJson(std::ostream &out, int indent) const { self->toJson(out, indent); }
-
 
   private:
     struct concept_t {
@@ -39,7 +38,6 @@ namespace smeagle {
       virtual std::string class_name() const = 0;
       virtual std::string direction() const = 0;
       virtual std::string location() const = 0;
-      virtual int pointer_indirections() const = 0;
       virtual size_t size_in_bytes() const = 0;
       virtual void toJson(std::ostream &, int) const = 0;
     };
@@ -50,7 +48,6 @@ namespace smeagle {
       std::string class_name() const override { return data.class_name(); }
       std::string direction() const override { return data.direction(); }
       std::string location() const override { return data.location(); }
-      int pointer_indirections() const override { return data.pointer_indirections(); }
       size_t size_in_bytes() const override { return data.size_in_bytes(); }
       void toJson(std::ostream &out, int indent) const { data.toJson(out, indent); }
 

--- a/source/corpora.cpp
+++ b/source/corpora.cpp
@@ -39,7 +39,7 @@ void Corpus::toJson() {
 
     for (auto const &p : f.parameters) {
       // Check if we are at the last entry (no comma) or not
-      auto endcomma = (&p == &f.parameters.back()) ? "":  ",";
+      auto endcomma = (&p == &f.parameters.back()) ? "" : ",";
       p.toJson(std::cout, 8);
       std::cout << endcomma << '\n';
     }

--- a/source/parser/x86_64/classifiers.hpp
+++ b/source/parser/x86_64/classifiers.hpp
@@ -73,7 +73,9 @@ namespace smeagle::x86_64 {
       }
     }
 
-    throw std::runtime_error{"Unknown scalar type"};
+    // TODO we will eventually want to throw this
+    // throw std::runtime_error{"Unknown scalar type"};
+    return {RegisterClass::NO_CLASS, RegisterClass::NO_CLASS, "Unknown"};
   }
 
   inline classification classify(st::typeStruct *) { return {}; }

--- a/source/parser/x86_64/types.hpp
+++ b/source/parser/x86_64/types.hpp
@@ -18,7 +18,6 @@ namespace smeagle::x86_64::types {
       std::string class_name_;
       std::string direction_;
       std::string location_;
-      int pointer_indirections_;
       size_t size_in_bytes_;
 
       std::string name() const { return name_; }
@@ -26,7 +25,6 @@ namespace smeagle::x86_64::types {
       std::string class_name() const { return class_name_; }
       std::string direction() const { return direction_; }
       std::string location() const { return location_; }
-      int pointer_indirections() const { return pointer_indirections_; }
       size_t size_in_bytes() const { return size_in_bytes_; }
     };
 
@@ -36,7 +34,6 @@ namespace smeagle::x86_64::types {
           << buf << "\"type\":\"" << p.type_name() << "\",\n"
           << buf << "\"class\":\"" << p.class_name() << "\",\n"
           << buf << "\"location\":\"" << p.location() << "\",\n"
-          << buf << "\"pointer_indirections\":\"" << p.pointer_indirections() << "\",\n"
           << buf << "\"direction\":\"" << p.direction() << "\",\n"
           << buf << "\"size\":\"" << p.size_in_bytes() << "\"";
     }
@@ -95,10 +92,14 @@ namespace smeagle::x86_64::types {
   };
   template <typename T> struct pointer_t final : detail::param {
     T underlying_type;
+    int pointer_indirections_;
+    int pointer_indirections() const { return pointer_indirections_; }
+
     void toJson(std::ostream &out, int indent) const {
       auto buf = std::string(indent, ' ');
       out << buf << "{\n";
       detail::toJson(*this, out, indent + 2);
+      out << ",\n" << buf << "  \"indirections\":\"" << pointer_indirections_ << "\"";
       out << ",\n" << buf << "  \"underlying_type\":\n";
       underlying_type.toJson(out, indent + 4);
       out << "\n" << buf << "}";

--- a/source/parser/x86_64/types.hpp
+++ b/source/parser/x86_64/types.hpp
@@ -91,15 +91,14 @@ namespace smeagle::x86_64::types {
     }
   };
   template <typename T> struct pointer_t final : detail::param {
+    int pointer_indirections;
     T underlying_type;
-    int pointer_indirections_;
-    int pointer_indirections() const { return pointer_indirections_; }
 
     void toJson(std::ostream &out, int indent) const {
       auto buf = std::string(indent, ' ');
       out << buf << "{\n";
       detail::toJson(*this, out, indent + 2);
-      out << ",\n" << buf << "  \"indirections\":\"" << pointer_indirections_ << "\"";
+      out << ",\n" << buf << "  \"indirections\":\"" << pointer_indirections << "\"";
       out << ",\n" << buf << "  \"underlying_type\":\n";
       underlying_type.toJson(out, indent + 4);
       out << "\n" << buf << "}";

--- a/source/parser/x86_64/x86_64.cpp
+++ b/source/parser/x86_64/x86_64.cpp
@@ -66,13 +66,12 @@ namespace smeagle::x86_64 {
           ptr_class.name,
           direction,
           ptr_loc,
-          ptr_cnt,
           param_type->getSize(),
-          {"", base_type_name, base_class.name, "", "", 0, base_type->getSize()}}};
+          {"", base_type_name, base_class.name, "", "", base_type->getSize()}}};
     }
     auto loc = allocator.getRegisterString(base_class.lo, base_class.hi, base_type);
-    return smeagle::parameter{class_t{param_name, base_type_name, base_class.name, direction, loc,
-                                      0, base_type->getSize()}};
+    return smeagle::parameter{
+        class_t{param_name, base_type_name, base_class.name, direction, loc, base_type->getSize()}};
   }
 
   std::vector<parameter> parse_parameters(st::Symbol *symbol) {

--- a/source/parser/x86_64/x86_64.cpp
+++ b/source/parser/x86_64/x86_64.cpp
@@ -67,6 +67,7 @@ namespace smeagle::x86_64 {
           direction,
           ptr_loc,
           param_type->getSize(),
+          ptr_cnt,
           {"", base_type_name, base_class.name, "", "", base_type->getSize()}}};
     }
     auto loc = allocator.getRegisterString(base_class.lo, base_class.hi, base_type);

--- a/test/source/allocation.cpp
+++ b/test/source/allocation.cpp
@@ -33,14 +33,12 @@ TEST_CASE("Register Allocation - Integral Types") {
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 1);
   }
   SUBCASE("bool**") {
     auto func = get_one(corpus, "test_ptr_ptr_bool");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 2);
   }
   SUBCASE("char") {
     auto func = get_one(corpus, "test_char");
@@ -53,14 +51,12 @@ TEST_CASE("Register Allocation - Integral Types") {
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 1);
   }
   SUBCASE("char**") {
     auto func = get_one(corpus, "test_ptr_ptr_char");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 2);
   }
   SUBCASE("short") {
     auto func = get_one(corpus, "test_short");
@@ -73,14 +69,12 @@ TEST_CASE("Register Allocation - Integral Types") {
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 1);
   }
   SUBCASE("short**") {
     auto func = get_one(corpus, "test_ptr_ptr_short");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 2);
   }
   SUBCASE("int") {
     auto func = get_one(corpus, "test_int");
@@ -93,14 +87,12 @@ TEST_CASE("Register Allocation - Integral Types") {
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 1);
   }
   SUBCASE("int**") {
     auto func = get_one(corpus, "test_ptr_ptr_int");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 2);
   }
   SUBCASE("long") {
     auto func = get_one(corpus, "test_long");
@@ -113,14 +105,12 @@ TEST_CASE("Register Allocation - Integral Types") {
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 1);
   }
   SUBCASE("long**") {
     auto func = get_one(corpus, "test_ptr_ptr_long");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 2);
   }
   SUBCASE("long long") {
     auto func = get_one(corpus, "test_long_long");
@@ -133,14 +123,12 @@ TEST_CASE("Register Allocation - Integral Types") {
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 1);
   }
   SUBCASE("long long**") {
     auto func = get_one(corpus, "test_ptr_ptr_long_long");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 2);
   }
 }
 TEST_CASE("Register Allocation - Signed Integral Types") {
@@ -155,14 +143,12 @@ TEST_CASE("Register Allocation - Signed Integral Types") {
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 1);
   }
   SUBCASE("signed**") {
     auto func = get_one(corpus, "test_ptr_ptr_signed");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 2);
   }
   SUBCASE("signed char") {
     auto func = get_one(corpus, "test_signed_char");
@@ -175,14 +161,12 @@ TEST_CASE("Register Allocation - Signed Integral Types") {
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 1);
   }
   SUBCASE("signed char**") {
     auto func = get_one(corpus, "test_ptr_ptr_signed_char");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 2);
   }
   SUBCASE("signed short") {
     auto func = get_one(corpus, "test_signed_short");
@@ -195,14 +179,12 @@ TEST_CASE("Register Allocation - Signed Integral Types") {
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 1);
   }
   SUBCASE("signed short**") {
     auto func = get_one(corpus, "test_ptr_ptr_signed_short");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 2);
   }
   SUBCASE("signed int") {
     auto func = get_one(corpus, "test_signed_int");
@@ -215,14 +197,12 @@ TEST_CASE("Register Allocation - Signed Integral Types") {
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 1);
   }
   SUBCASE("signed int**") {
     auto func = get_one(corpus, "test_ptr_ptr_signed_int");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 2);
   }
   SUBCASE("signed long") {
     auto func = get_one(corpus, "test_signed_long");
@@ -235,14 +215,12 @@ TEST_CASE("Register Allocation - Signed Integral Types") {
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 1);
   }
   SUBCASE("signed long**") {
     auto func = get_one(corpus, "test_ptr_ptr_signed_long");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 2);
   }
   SUBCASE("signed long long") {
     auto func = get_one(corpus, "test_signed_long_long");
@@ -255,14 +233,12 @@ TEST_CASE("Register Allocation - Signed Integral Types") {
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 1);
   }
   SUBCASE("signed long long**") {
     auto func = get_one(corpus, "test_ptr_ptr_signed_long_long");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 2);
   }
 }
 TEST_CASE("Register Allocation - Unsigned Integral Types") {
@@ -277,14 +253,12 @@ TEST_CASE("Register Allocation - Unsigned Integral Types") {
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 1);
   }
   SUBCASE("unsigned**") {
     auto func = get_one(corpus, "test_ptr_ptr_unsigned");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 2);
   }
   SUBCASE("unsigned char") {
     auto func = get_one(corpus, "test_unsigned_char");
@@ -297,14 +271,12 @@ TEST_CASE("Register Allocation - Unsigned Integral Types") {
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 1);
   }
   SUBCASE("unsigned char**") {
     auto func = get_one(corpus, "test_ptr_ptr_unsigned_char");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 2);
   }
   SUBCASE("unsigned short") {
     auto func = get_one(corpus, "test_unsigned_short");
@@ -317,14 +289,12 @@ TEST_CASE("Register Allocation - Unsigned Integral Types") {
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 1);
   }
   SUBCASE("unsigned short**") {
     auto func = get_one(corpus, "test_ptr_ptr_unsigned_short");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 2);
   }
   SUBCASE("unsigned int") {
     auto func = get_one(corpus, "test_unsigned_int");
@@ -337,14 +307,12 @@ TEST_CASE("Register Allocation - Unsigned Integral Types") {
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 1);
   }
   SUBCASE("unsigned int**") {
     auto func = get_one(corpus, "test_ptr_ptr_unsigned_int");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 2);
   }
   SUBCASE("unsigned long") {
     auto func = get_one(corpus, "test_unsigned_long");
@@ -357,14 +325,12 @@ TEST_CASE("Register Allocation - Unsigned Integral Types") {
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 1);
   }
   SUBCASE("unsigned long**") {
     auto func = get_one(corpus, "test_ptr_ptr_unsigned_long");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 2);
   }
   SUBCASE("unsigned long long") {
     auto func = get_one(corpus, "test_unsigned_long_long");
@@ -377,14 +343,12 @@ TEST_CASE("Register Allocation - Unsigned Integral Types") {
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 1);
   }
   SUBCASE("unsigned long long**") {
     auto func = get_one(corpus, "test_ptr_ptr_unsigned_long_long");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 2);
   }
 }
 TEST_CASE("Register Allocation - Floating Point Types") {
@@ -399,14 +363,12 @@ TEST_CASE("Register Allocation - Floating Point Types") {
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 1);
   }
   SUBCASE("float**") {
     auto func = get_one(corpus, "test_ptr_ptr_float");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 2);
   }
   SUBCASE("double") {
     auto func = get_one(corpus, "test_double");
@@ -419,14 +381,12 @@ TEST_CASE("Register Allocation - Floating Point Types") {
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 1);
   }
   SUBCASE("double**") {
     auto func = get_one(corpus, "test_ptr_ptr_double");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 2);
   }
   SUBCASE("long double") {
     auto func = get_one(corpus, "test_long_double");
@@ -439,14 +399,12 @@ TEST_CASE("Register Allocation - Floating Point Types") {
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 1);
   }
   SUBCASE("long double**") {
     auto func = get_one(corpus, "test_ptr_ptr_long_double");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 2);
   }
   SUBCASE("float _Complex") {
     auto func = get_one(corpus, "test_float__Complex");
@@ -459,14 +417,12 @@ TEST_CASE("Register Allocation - Floating Point Types") {
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 1);
   }
   SUBCASE("float _Complex**") {
     auto func = get_one(corpus, "test_ptr_ptr_float__Complex");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 2);
   }
   SUBCASE("double _Complex") {
     auto func = get_one(corpus, "test_double__Complex");
@@ -479,14 +435,12 @@ TEST_CASE("Register Allocation - Floating Point Types") {
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 1);
   }
   SUBCASE("double _Complex**") {
     auto func = get_one(corpus, "test_ptr_ptr_double__Complex");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 2);
   }
   SUBCASE("long double _Complex") {
     auto func = get_one(corpus, "test_long_double__Complex");
@@ -499,14 +453,12 @@ TEST_CASE("Register Allocation - Floating Point Types") {
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 1);
   }
   SUBCASE("long double _Complex**") {
     auto func = get_one(corpus, "test_ptr_ptr_long_double__Complex");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 2);
   }
 }
 TEST_CASE("Register Allocation - UTF Types") {
@@ -521,14 +473,12 @@ TEST_CASE("Register Allocation - UTF Types") {
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 1);
   }
   SUBCASE("wchar_t**") {
     auto func = get_one(corpus, "test_ptr_ptr_wchar_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 2);
   }
   SUBCASE("char16_t") {
     auto func = get_one(corpus, "test_char16_t");
@@ -541,14 +491,12 @@ TEST_CASE("Register Allocation - UTF Types") {
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 1);
   }
   SUBCASE("char16_t**") {
     auto func = get_one(corpus, "test_ptr_ptr_char16_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 2);
   }
   SUBCASE("char32_t") {
     auto func = get_one(corpus, "test_char32_t");
@@ -561,14 +509,12 @@ TEST_CASE("Register Allocation - UTF Types") {
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 1);
   }
   SUBCASE("char32_t**") {
     auto func = get_one(corpus, "test_ptr_ptr_char32_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 2);
   }
 }
 TEST_CASE("Register Allocation - Size Types") {
@@ -583,14 +529,12 @@ TEST_CASE("Register Allocation - Size Types") {
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 1);
   }
   SUBCASE("size_t**") {
     auto func = get_one(corpus, "test_ptr_ptr_size_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 2);
   }
   SUBCASE("intmax_t") {
     auto func = get_one(corpus, "test_intmax_t");
@@ -603,14 +547,12 @@ TEST_CASE("Register Allocation - Size Types") {
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 1);
   }
   SUBCASE("intmax_t**") {
     auto func = get_one(corpus, "test_ptr_ptr_intmax_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 2);
   }
   SUBCASE("uintmax_t") {
     auto func = get_one(corpus, "test_uintmax_t");
@@ -623,14 +565,12 @@ TEST_CASE("Register Allocation - Size Types") {
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 1);
   }
   SUBCASE("uintmax_t**") {
     auto func = get_one(corpus, "test_ptr_ptr_uintmax_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 2);
   }
   SUBCASE("intptr_t") {
     auto func = get_one(corpus, "test_intptr_t");
@@ -643,14 +583,12 @@ TEST_CASE("Register Allocation - Size Types") {
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 1);
   }
   SUBCASE("intptr_t**") {
     auto func = get_one(corpus, "test_ptr_ptr_intptr_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 2);
   }
   SUBCASE("uintptr_t") {
     auto func = get_one(corpus, "test_uintptr_t");
@@ -663,14 +601,12 @@ TEST_CASE("Register Allocation - Size Types") {
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 1);
   }
   SUBCASE("uintptr_t**") {
     auto func = get_one(corpus, "test_ptr_ptr_uintptr_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 2);
   }
 }
 TEST_CASE("Register Allocation - Fixed-width Integral Types") {
@@ -685,14 +621,12 @@ TEST_CASE("Register Allocation - Fixed-width Integral Types") {
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 1);
   }
   SUBCASE("int8_t**") {
     auto func = get_one(corpus, "test_ptr_ptr_int8_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 2);
   }
   SUBCASE("int16_t") {
     auto func = get_one(corpus, "test_int16_t");
@@ -705,14 +639,12 @@ TEST_CASE("Register Allocation - Fixed-width Integral Types") {
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 1);
   }
   SUBCASE("int16_t**") {
     auto func = get_one(corpus, "test_ptr_ptr_int16_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 2);
   }
   SUBCASE("int32_t") {
     auto func = get_one(corpus, "test_int32_t");
@@ -725,14 +657,12 @@ TEST_CASE("Register Allocation - Fixed-width Integral Types") {
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 1);
   }
   SUBCASE("int32_t**") {
     auto func = get_one(corpus, "test_ptr_ptr_int32_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 2);
   }
   SUBCASE("int64_t") {
     auto func = get_one(corpus, "test_int64_t");
@@ -745,14 +675,12 @@ TEST_CASE("Register Allocation - Fixed-width Integral Types") {
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 1);
   }
   SUBCASE("int64_t**") {
     auto func = get_one(corpus, "test_ptr_ptr_int64_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 2);
   }
   SUBCASE("int_fast8_t") {
     auto func = get_one(corpus, "test_int_fast8_t");
@@ -765,14 +693,12 @@ TEST_CASE("Register Allocation - Fixed-width Integral Types") {
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 1);
   }
   SUBCASE("int_fast8_t**") {
     auto func = get_one(corpus, "test_ptr_ptr_int_fast8_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 2);
   }
   SUBCASE("int_fast16_t") {
     auto func = get_one(corpus, "test_int_fast16_t");
@@ -785,14 +711,12 @@ TEST_CASE("Register Allocation - Fixed-width Integral Types") {
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 1);
   }
   SUBCASE("int_fast16_t**") {
     auto func = get_one(corpus, "test_ptr_ptr_int_fast16_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 2);
   }
   SUBCASE("int_fast32_t") {
     auto func = get_one(corpus, "test_int_fast32_t");
@@ -805,14 +729,12 @@ TEST_CASE("Register Allocation - Fixed-width Integral Types") {
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 1);
   }
   SUBCASE("int_fast32_t**") {
     auto func = get_one(corpus, "test_ptr_ptr_int_fast32_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 2);
   }
   SUBCASE("int_fast64_t") {
     auto func = get_one(corpus, "test_int_fast64_t");
@@ -825,14 +747,12 @@ TEST_CASE("Register Allocation - Fixed-width Integral Types") {
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 1);
   }
   SUBCASE("int_fast64_t**") {
     auto func = get_one(corpus, "test_ptr_ptr_int_fast64_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 2);
   }
   SUBCASE("int_least8_t") {
     auto func = get_one(corpus, "test_int_least8_t");
@@ -845,14 +765,12 @@ TEST_CASE("Register Allocation - Fixed-width Integral Types") {
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 1);
   }
   SUBCASE("int_least8_t**") {
     auto func = get_one(corpus, "test_ptr_ptr_int_least8_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 2);
   }
   SUBCASE("int_least16_t") {
     auto func = get_one(corpus, "test_int_least16_t");
@@ -865,14 +783,12 @@ TEST_CASE("Register Allocation - Fixed-width Integral Types") {
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 1);
   }
   SUBCASE("int_least16_t**") {
     auto func = get_one(corpus, "test_ptr_ptr_int_least16_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 2);
   }
   SUBCASE("int_least32_t") {
     auto func = get_one(corpus, "test_int_least32_t");
@@ -885,14 +801,12 @@ TEST_CASE("Register Allocation - Fixed-width Integral Types") {
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 1);
   }
   SUBCASE("int_least32_t**") {
     auto func = get_one(corpus, "test_ptr_ptr_int_least32_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 2);
   }
   SUBCASE("int_least64_t") {
     auto func = get_one(corpus, "test_int_least64_t");
@@ -905,14 +819,12 @@ TEST_CASE("Register Allocation - Fixed-width Integral Types") {
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 1);
   }
   SUBCASE("int_least64_t**") {
     auto func = get_one(corpus, "test_ptr_ptr_int_least64_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 2);
   }
 }
 TEST_CASE("Register Allocation - Unsigned Fixed-width Integral Types") {
@@ -927,14 +839,12 @@ TEST_CASE("Register Allocation - Unsigned Fixed-width Integral Types") {
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 1);
   }
   SUBCASE("uint8_t**") {
     auto func = get_one(corpus, "test_ptr_ptr_uint8_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 2);
   }
   SUBCASE("uint16_t") {
     auto func = get_one(corpus, "test_uint16_t");
@@ -947,14 +857,12 @@ TEST_CASE("Register Allocation - Unsigned Fixed-width Integral Types") {
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 1);
   }
   SUBCASE("uint16_t**") {
     auto func = get_one(corpus, "test_ptr_ptr_uint16_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 2);
   }
   SUBCASE("uint32_t") {
     auto func = get_one(corpus, "test_uint32_t");
@@ -967,14 +875,12 @@ TEST_CASE("Register Allocation - Unsigned Fixed-width Integral Types") {
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 1);
   }
   SUBCASE("uint32_t**") {
     auto func = get_one(corpus, "test_ptr_ptr_uint32_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 2);
   }
   SUBCASE("uint64_t") {
     auto func = get_one(corpus, "test_uint64_t");
@@ -987,14 +893,12 @@ TEST_CASE("Register Allocation - Unsigned Fixed-width Integral Types") {
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 1);
   }
   SUBCASE("uint64_t**") {
     auto func = get_one(corpus, "test_ptr_ptr_uint64_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 2);
   }
   SUBCASE("uint_fast8_t") {
     auto func = get_one(corpus, "test_uint_fast8_t");
@@ -1007,14 +911,12 @@ TEST_CASE("Register Allocation - Unsigned Fixed-width Integral Types") {
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 1);
   }
   SUBCASE("uint_fast8_t**") {
     auto func = get_one(corpus, "test_ptr_ptr_uint_fast8_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 2);
   }
   SUBCASE("uint_fast16_t") {
     auto func = get_one(corpus, "test_uint_fast16_t");
@@ -1027,14 +929,12 @@ TEST_CASE("Register Allocation - Unsigned Fixed-width Integral Types") {
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 1);
   }
   SUBCASE("uint_fast16_t**") {
     auto func = get_one(corpus, "test_ptr_ptr_uint_fast16_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 2);
   }
   SUBCASE("uint_fast32_t") {
     auto func = get_one(corpus, "test_uint_fast32_t");
@@ -1047,14 +947,12 @@ TEST_CASE("Register Allocation - Unsigned Fixed-width Integral Types") {
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 1);
   }
   SUBCASE("uint_fast32_t**") {
     auto func = get_one(corpus, "test_ptr_ptr_uint_fast32_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 2);
   }
   SUBCASE("uint_fast64_t") {
     auto func = get_one(corpus, "test_uint_fast64_t");
@@ -1067,14 +965,12 @@ TEST_CASE("Register Allocation - Unsigned Fixed-width Integral Types") {
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 1);
   }
   SUBCASE("uint_fast64_t**") {
     auto func = get_one(corpus, "test_ptr_ptr_uint_fast64_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 2);
   }
   SUBCASE("uint_least8_t") {
     auto func = get_one(corpus, "test_uint_least8_t");
@@ -1087,14 +983,12 @@ TEST_CASE("Register Allocation - Unsigned Fixed-width Integral Types") {
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 1);
   }
   SUBCASE("uint_least8_t**") {
     auto func = get_one(corpus, "test_ptr_ptr_uint_least8_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 2);
   }
   SUBCASE("uint_least16_t") {
     auto func = get_one(corpus, "test_uint_least16_t");
@@ -1107,14 +1001,12 @@ TEST_CASE("Register Allocation - Unsigned Fixed-width Integral Types") {
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 1);
   }
   SUBCASE("uint_least16_t**") {
     auto func = get_one(corpus, "test_ptr_ptr_uint_least16_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 2);
   }
   SUBCASE("uint_least32_t") {
     auto func = get_one(corpus, "test_uint_least32_t");
@@ -1127,14 +1019,12 @@ TEST_CASE("Register Allocation - Unsigned Fixed-width Integral Types") {
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 1);
   }
   SUBCASE("uint_least32_t**") {
     auto func = get_one(corpus, "test_ptr_ptr_uint_least32_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 2);
   }
   SUBCASE("uint_least64_t") {
     auto func = get_one(corpus, "test_uint_least64_t");
@@ -1147,14 +1037,12 @@ TEST_CASE("Register Allocation - Unsigned Fixed-width Integral Types") {
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 1);
   }
   SUBCASE("uint_least64_t**") {
     auto func = get_one(corpus, "test_ptr_ptr_uint_least64_t");
     auto const& parameters = func.parameters;
     CHECK(parameters[0].location() == "%rdi");
     CHECK(parameters[0].class_name() == "Pointer");
-    CHECK(parameters[0].pointer_indirections() == 2);
   }
 }
 

--- a/test/source/libs/allocation.cpp
+++ b/test/source/libs/allocation.cpp
@@ -1,191 +1,192 @@
 
 // Functions to test register allocation
 #include <complex.h>
+
 #include <iostream>
 
 // Integral Types
-extern "C" void test_bool(bool x){}
-extern "C" void test_ptr_bool(bool* x){}
-extern "C" void test_ptr_ptr_bool(bool** x){}
-extern "C" void test_char(char x){}
-extern "C" void test_ptr_char(char* x){}
-extern "C" void test_ptr_ptr_char(char** x){}
-extern "C" void test_short(short x){}
-extern "C" void test_ptr_short(short* x){}
-extern "C" void test_ptr_ptr_short(short** x){}
-extern "C" void test_int(int x){}
-extern "C" void test_ptr_int(int* x){}
-extern "C" void test_ptr_ptr_int(int** x){}
-extern "C" void test_long(long x){}
-extern "C" void test_ptr_long(long* x){}
-extern "C" void test_ptr_ptr_long(long** x){}
-extern "C" void test_long_long(long long x){}
-extern "C" void test_ptr_long_long(long long* x){}
-extern "C" void test_ptr_ptr_long_long(long long** x){}
+extern "C" void test_bool(bool x) {}
+extern "C" void test_ptr_bool(bool* x) {}
+extern "C" void test_ptr_ptr_bool(bool** x) {}
+extern "C" void test_char(char x) {}
+extern "C" void test_ptr_char(char* x) {}
+extern "C" void test_ptr_ptr_char(char** x) {}
+extern "C" void test_short(short x) {}
+extern "C" void test_ptr_short(short* x) {}
+extern "C" void test_ptr_ptr_short(short** x) {}
+extern "C" void test_int(int x) {}
+extern "C" void test_ptr_int(int* x) {}
+extern "C" void test_ptr_ptr_int(int** x) {}
+extern "C" void test_long(long x) {}
+extern "C" void test_ptr_long(long* x) {}
+extern "C" void test_ptr_ptr_long(long** x) {}
+extern "C" void test_long_long(long long x) {}
+extern "C" void test_ptr_long_long(long long* x) {}
+extern "C" void test_ptr_ptr_long_long(long long** x) {}
 
 // Signed Integral Types
-extern "C" void test_signed(signed x){}
-extern "C" void test_ptr_signed(signed* x){}
-extern "C" void test_ptr_ptr_signed(signed** x){}
-extern "C" void test_signed_char(signed char x){}
-extern "C" void test_ptr_signed_char(signed char* x){}
-extern "C" void test_ptr_ptr_signed_char(signed char** x){}
-extern "C" void test_signed_short(signed short x){}
-extern "C" void test_ptr_signed_short(signed short* x){}
-extern "C" void test_ptr_ptr_signed_short(signed short** x){}
-extern "C" void test_signed_int(signed int x){}
-extern "C" void test_ptr_signed_int(signed int* x){}
-extern "C" void test_ptr_ptr_signed_int(signed int** x){}
-extern "C" void test_signed_long(signed long x){}
-extern "C" void test_ptr_signed_long(signed long* x){}
-extern "C" void test_ptr_ptr_signed_long(signed long** x){}
-extern "C" void test_signed_long_long(signed long long x){}
-extern "C" void test_ptr_signed_long_long(signed long long* x){}
-extern "C" void test_ptr_ptr_signed_long_long(signed long long** x){}
+extern "C" void test_signed(signed x) {}
+extern "C" void test_ptr_signed(signed* x) {}
+extern "C" void test_ptr_ptr_signed(signed** x) {}
+extern "C" void test_signed_char(signed char x) {}
+extern "C" void test_ptr_signed_char(signed char* x) {}
+extern "C" void test_ptr_ptr_signed_char(signed char** x) {}
+extern "C" void test_signed_short(signed short x) {}
+extern "C" void test_ptr_signed_short(signed short* x) {}
+extern "C" void test_ptr_ptr_signed_short(signed short** x) {}
+extern "C" void test_signed_int(signed int x) {}
+extern "C" void test_ptr_signed_int(signed int* x) {}
+extern "C" void test_ptr_ptr_signed_int(signed int** x) {}
+extern "C" void test_signed_long(signed long x) {}
+extern "C" void test_ptr_signed_long(signed long* x) {}
+extern "C" void test_ptr_ptr_signed_long(signed long** x) {}
+extern "C" void test_signed_long_long(signed long long x) {}
+extern "C" void test_ptr_signed_long_long(signed long long* x) {}
+extern "C" void test_ptr_ptr_signed_long_long(signed long long** x) {}
 
 // Unsigned Integral Types
-extern "C" void test_unsigned(unsigned x){}
-extern "C" void test_ptr_unsigned(unsigned* x){}
-extern "C" void test_ptr_ptr_unsigned(unsigned** x){}
-extern "C" void test_unsigned_char(unsigned char x){}
-extern "C" void test_ptr_unsigned_char(unsigned char* x){}
-extern "C" void test_ptr_ptr_unsigned_char(unsigned char** x){}
-extern "C" void test_unsigned_short(unsigned short x){}
-extern "C" void test_ptr_unsigned_short(unsigned short* x){}
-extern "C" void test_ptr_ptr_unsigned_short(unsigned short** x){}
-extern "C" void test_unsigned_int(unsigned int x){}
-extern "C" void test_ptr_unsigned_int(unsigned int* x){}
-extern "C" void test_ptr_ptr_unsigned_int(unsigned int** x){}
-extern "C" void test_unsigned_long(unsigned long x){}
-extern "C" void test_ptr_unsigned_long(unsigned long* x){}
-extern "C" void test_ptr_ptr_unsigned_long(unsigned long** x){}
-extern "C" void test_unsigned_long_long(unsigned long long x){}
-extern "C" void test_ptr_unsigned_long_long(unsigned long long* x){}
-extern "C" void test_ptr_ptr_unsigned_long_long(unsigned long long** x){}
+extern "C" void test_unsigned(unsigned x) {}
+extern "C" void test_ptr_unsigned(unsigned* x) {}
+extern "C" void test_ptr_ptr_unsigned(unsigned** x) {}
+extern "C" void test_unsigned_char(unsigned char x) {}
+extern "C" void test_ptr_unsigned_char(unsigned char* x) {}
+extern "C" void test_ptr_ptr_unsigned_char(unsigned char** x) {}
+extern "C" void test_unsigned_short(unsigned short x) {}
+extern "C" void test_ptr_unsigned_short(unsigned short* x) {}
+extern "C" void test_ptr_ptr_unsigned_short(unsigned short** x) {}
+extern "C" void test_unsigned_int(unsigned int x) {}
+extern "C" void test_ptr_unsigned_int(unsigned int* x) {}
+extern "C" void test_ptr_ptr_unsigned_int(unsigned int** x) {}
+extern "C" void test_unsigned_long(unsigned long x) {}
+extern "C" void test_ptr_unsigned_long(unsigned long* x) {}
+extern "C" void test_ptr_ptr_unsigned_long(unsigned long** x) {}
+extern "C" void test_unsigned_long_long(unsigned long long x) {}
+extern "C" void test_ptr_unsigned_long_long(unsigned long long* x) {}
+extern "C" void test_ptr_ptr_unsigned_long_long(unsigned long long** x) {}
 
 // Floating Point Types
-extern "C" void test_float(float x){}
-extern "C" void test_ptr_float(float* x){}
-extern "C" void test_ptr_ptr_float(float** x){}
-extern "C" void test_double(double x){}
-extern "C" void test_ptr_double(double* x){}
-extern "C" void test_ptr_ptr_double(double** x){}
-extern "C" void test_long_double(long double x){}
-extern "C" void test_ptr_long_double(long double* x){}
-extern "C" void test_ptr_ptr_long_double(long double** x){}
-extern "C" void test_float__Complex(float _Complex x){}
-extern "C" void test_ptr_float__Complex(float _Complex* x){}
-extern "C" void test_ptr_ptr_float__Complex(float _Complex** x){}
-extern "C" void test_double__Complex(double _Complex x){}
-extern "C" void test_ptr_double__Complex(double _Complex* x){}
-extern "C" void test_ptr_ptr_double__Complex(double _Complex** x){}
-extern "C" void test_long_double__Complex(long double _Complex x){}
-extern "C" void test_ptr_long_double__Complex(long double _Complex* x){}
-extern "C" void test_ptr_ptr_long_double__Complex(long double _Complex** x){}
+extern "C" void test_float(float x) {}
+extern "C" void test_ptr_float(float* x) {}
+extern "C" void test_ptr_ptr_float(float** x) {}
+extern "C" void test_double(double x) {}
+extern "C" void test_ptr_double(double* x) {}
+extern "C" void test_ptr_ptr_double(double** x) {}
+extern "C" void test_long_double(long double x) {}
+extern "C" void test_ptr_long_double(long double* x) {}
+extern "C" void test_ptr_ptr_long_double(long double** x) {}
+extern "C" void test_float__Complex(float _Complex x) {}
+extern "C" void test_ptr_float__Complex(float _Complex* x) {}
+extern "C" void test_ptr_ptr_float__Complex(float _Complex** x) {}
+extern "C" void test_double__Complex(double _Complex x) {}
+extern "C" void test_ptr_double__Complex(double _Complex* x) {}
+extern "C" void test_ptr_ptr_double__Complex(double _Complex** x) {}
+extern "C" void test_long_double__Complex(long double _Complex x) {}
+extern "C" void test_ptr_long_double__Complex(long double _Complex* x) {}
+extern "C" void test_ptr_ptr_long_double__Complex(long double _Complex** x) {}
 
 // UTF Types
-extern "C" void test_wchar_t(wchar_t x){}
-extern "C" void test_ptr_wchar_t(wchar_t* x){}
-extern "C" void test_ptr_ptr_wchar_t(wchar_t** x){}
-extern "C" void test_char16_t(char16_t x){}
-extern "C" void test_ptr_char16_t(char16_t* x){}
-extern "C" void test_ptr_ptr_char16_t(char16_t** x){}
-extern "C" void test_char32_t(char32_t x){}
-extern "C" void test_ptr_char32_t(char32_t* x){}
-extern "C" void test_ptr_ptr_char32_t(char32_t** x){}
+extern "C" void test_wchar_t(wchar_t x) {}
+extern "C" void test_ptr_wchar_t(wchar_t* x) {}
+extern "C" void test_ptr_ptr_wchar_t(wchar_t** x) {}
+extern "C" void test_char16_t(char16_t x) {}
+extern "C" void test_ptr_char16_t(char16_t* x) {}
+extern "C" void test_ptr_ptr_char16_t(char16_t** x) {}
+extern "C" void test_char32_t(char32_t x) {}
+extern "C" void test_ptr_char32_t(char32_t* x) {}
+extern "C" void test_ptr_ptr_char32_t(char32_t** x) {}
 
 // Size Types
-extern "C" void test_size_t(size_t x){}
-extern "C" void test_ptr_size_t(size_t* x){}
-extern "C" void test_ptr_ptr_size_t(size_t** x){}
-extern "C" void test_intmax_t(intmax_t x){}
-extern "C" void test_ptr_intmax_t(intmax_t* x){}
-extern "C" void test_ptr_ptr_intmax_t(intmax_t** x){}
-extern "C" void test_uintmax_t(uintmax_t x){}
-extern "C" void test_ptr_uintmax_t(uintmax_t* x){}
-extern "C" void test_ptr_ptr_uintmax_t(uintmax_t** x){}
-extern "C" void test_intptr_t(intptr_t x){}
-extern "C" void test_ptr_intptr_t(intptr_t* x){}
-extern "C" void test_ptr_ptr_intptr_t(intptr_t** x){}
-extern "C" void test_uintptr_t(uintptr_t x){}
-extern "C" void test_ptr_uintptr_t(uintptr_t* x){}
-extern "C" void test_ptr_ptr_uintptr_t(uintptr_t** x){}
+extern "C" void test_size_t(size_t x) {}
+extern "C" void test_ptr_size_t(size_t* x) {}
+extern "C" void test_ptr_ptr_size_t(size_t** x) {}
+extern "C" void test_intmax_t(intmax_t x) {}
+extern "C" void test_ptr_intmax_t(intmax_t* x) {}
+extern "C" void test_ptr_ptr_intmax_t(intmax_t** x) {}
+extern "C" void test_uintmax_t(uintmax_t x) {}
+extern "C" void test_ptr_uintmax_t(uintmax_t* x) {}
+extern "C" void test_ptr_ptr_uintmax_t(uintmax_t** x) {}
+extern "C" void test_intptr_t(intptr_t x) {}
+extern "C" void test_ptr_intptr_t(intptr_t* x) {}
+extern "C" void test_ptr_ptr_intptr_t(intptr_t** x) {}
+extern "C" void test_uintptr_t(uintptr_t x) {}
+extern "C" void test_ptr_uintptr_t(uintptr_t* x) {}
+extern "C" void test_ptr_ptr_uintptr_t(uintptr_t** x) {}
 
 // Fixed-width Integral Types
-extern "C" void test_int8_t(int8_t x){}
-extern "C" void test_ptr_int8_t(int8_t* x){}
-extern "C" void test_ptr_ptr_int8_t(int8_t** x){}
-extern "C" void test_int16_t(int16_t x){}
-extern "C" void test_ptr_int16_t(int16_t* x){}
-extern "C" void test_ptr_ptr_int16_t(int16_t** x){}
-extern "C" void test_int32_t(int32_t x){}
-extern "C" void test_ptr_int32_t(int32_t* x){}
-extern "C" void test_ptr_ptr_int32_t(int32_t** x){}
-extern "C" void test_int64_t(int64_t x){}
-extern "C" void test_ptr_int64_t(int64_t* x){}
-extern "C" void test_ptr_ptr_int64_t(int64_t** x){}
-extern "C" void test_int_fast8_t(int_fast8_t x){}
-extern "C" void test_ptr_int_fast8_t(int_fast8_t* x){}
-extern "C" void test_ptr_ptr_int_fast8_t(int_fast8_t** x){}
-extern "C" void test_int_fast16_t(int_fast16_t x){}
-extern "C" void test_ptr_int_fast16_t(int_fast16_t* x){}
-extern "C" void test_ptr_ptr_int_fast16_t(int_fast16_t** x){}
-extern "C" void test_int_fast32_t(int_fast32_t x){}
-extern "C" void test_ptr_int_fast32_t(int_fast32_t* x){}
-extern "C" void test_ptr_ptr_int_fast32_t(int_fast32_t** x){}
-extern "C" void test_int_fast64_t(int_fast64_t x){}
-extern "C" void test_ptr_int_fast64_t(int_fast64_t* x){}
-extern "C" void test_ptr_ptr_int_fast64_t(int_fast64_t** x){}
-extern "C" void test_int_least8_t(int_least8_t x){}
-extern "C" void test_ptr_int_least8_t(int_least8_t* x){}
-extern "C" void test_ptr_ptr_int_least8_t(int_least8_t** x){}
-extern "C" void test_int_least16_t(int_least16_t x){}
-extern "C" void test_ptr_int_least16_t(int_least16_t* x){}
-extern "C" void test_ptr_ptr_int_least16_t(int_least16_t** x){}
-extern "C" void test_int_least32_t(int_least32_t x){}
-extern "C" void test_ptr_int_least32_t(int_least32_t* x){}
-extern "C" void test_ptr_ptr_int_least32_t(int_least32_t** x){}
-extern "C" void test_int_least64_t(int_least64_t x){}
-extern "C" void test_ptr_int_least64_t(int_least64_t* x){}
-extern "C" void test_ptr_ptr_int_least64_t(int_least64_t** x){}
+extern "C" void test_int8_t(int8_t x) {}
+extern "C" void test_ptr_int8_t(int8_t* x) {}
+extern "C" void test_ptr_ptr_int8_t(int8_t** x) {}
+extern "C" void test_int16_t(int16_t x) {}
+extern "C" void test_ptr_int16_t(int16_t* x) {}
+extern "C" void test_ptr_ptr_int16_t(int16_t** x) {}
+extern "C" void test_int32_t(int32_t x) {}
+extern "C" void test_ptr_int32_t(int32_t* x) {}
+extern "C" void test_ptr_ptr_int32_t(int32_t** x) {}
+extern "C" void test_int64_t(int64_t x) {}
+extern "C" void test_ptr_int64_t(int64_t* x) {}
+extern "C" void test_ptr_ptr_int64_t(int64_t** x) {}
+extern "C" void test_int_fast8_t(int_fast8_t x) {}
+extern "C" void test_ptr_int_fast8_t(int_fast8_t* x) {}
+extern "C" void test_ptr_ptr_int_fast8_t(int_fast8_t** x) {}
+extern "C" void test_int_fast16_t(int_fast16_t x) {}
+extern "C" void test_ptr_int_fast16_t(int_fast16_t* x) {}
+extern "C" void test_ptr_ptr_int_fast16_t(int_fast16_t** x) {}
+extern "C" void test_int_fast32_t(int_fast32_t x) {}
+extern "C" void test_ptr_int_fast32_t(int_fast32_t* x) {}
+extern "C" void test_ptr_ptr_int_fast32_t(int_fast32_t** x) {}
+extern "C" void test_int_fast64_t(int_fast64_t x) {}
+extern "C" void test_ptr_int_fast64_t(int_fast64_t* x) {}
+extern "C" void test_ptr_ptr_int_fast64_t(int_fast64_t** x) {}
+extern "C" void test_int_least8_t(int_least8_t x) {}
+extern "C" void test_ptr_int_least8_t(int_least8_t* x) {}
+extern "C" void test_ptr_ptr_int_least8_t(int_least8_t** x) {}
+extern "C" void test_int_least16_t(int_least16_t x) {}
+extern "C" void test_ptr_int_least16_t(int_least16_t* x) {}
+extern "C" void test_ptr_ptr_int_least16_t(int_least16_t** x) {}
+extern "C" void test_int_least32_t(int_least32_t x) {}
+extern "C" void test_ptr_int_least32_t(int_least32_t* x) {}
+extern "C" void test_ptr_ptr_int_least32_t(int_least32_t** x) {}
+extern "C" void test_int_least64_t(int_least64_t x) {}
+extern "C" void test_ptr_int_least64_t(int_least64_t* x) {}
+extern "C" void test_ptr_ptr_int_least64_t(int_least64_t** x) {}
 
 // Unsigned Fixed-width Integral Types
-extern "C" void test_uint8_t(uint8_t x){}
-extern "C" void test_ptr_uint8_t(uint8_t* x){}
-extern "C" void test_ptr_ptr_uint8_t(uint8_t** x){}
-extern "C" void test_uint16_t(uint16_t x){}
-extern "C" void test_ptr_uint16_t(uint16_t* x){}
-extern "C" void test_ptr_ptr_uint16_t(uint16_t** x){}
-extern "C" void test_uint32_t(uint32_t x){}
-extern "C" void test_ptr_uint32_t(uint32_t* x){}
-extern "C" void test_ptr_ptr_uint32_t(uint32_t** x){}
-extern "C" void test_uint64_t(uint64_t x){}
-extern "C" void test_ptr_uint64_t(uint64_t* x){}
-extern "C" void test_ptr_ptr_uint64_t(uint64_t** x){}
-extern "C" void test_uint_fast8_t(uint_fast8_t x){}
-extern "C" void test_ptr_uint_fast8_t(uint_fast8_t* x){}
-extern "C" void test_ptr_ptr_uint_fast8_t(uint_fast8_t** x){}
-extern "C" void test_uint_fast16_t(uint_fast16_t x){}
-extern "C" void test_ptr_uint_fast16_t(uint_fast16_t* x){}
-extern "C" void test_ptr_ptr_uint_fast16_t(uint_fast16_t** x){}
-extern "C" void test_uint_fast32_t(uint_fast32_t x){}
-extern "C" void test_ptr_uint_fast32_t(uint_fast32_t* x){}
-extern "C" void test_ptr_ptr_uint_fast32_t(uint_fast32_t** x){}
-extern "C" void test_uint_fast64_t(uint_fast64_t x){}
-extern "C" void test_ptr_uint_fast64_t(uint_fast64_t* x){}
-extern "C" void test_ptr_ptr_uint_fast64_t(uint_fast64_t** x){}
-extern "C" void test_uint_least8_t(uint_least8_t x){}
-extern "C" void test_ptr_uint_least8_t(uint_least8_t* x){}
-extern "C" void test_ptr_ptr_uint_least8_t(uint_least8_t** x){}
-extern "C" void test_uint_least16_t(uint_least16_t x){}
-extern "C" void test_ptr_uint_least16_t(uint_least16_t* x){}
-extern "C" void test_ptr_ptr_uint_least16_t(uint_least16_t** x){}
-extern "C" void test_uint_least32_t(uint_least32_t x){}
-extern "C" void test_ptr_uint_least32_t(uint_least32_t* x){}
-extern "C" void test_ptr_ptr_uint_least32_t(uint_least32_t** x){}
-extern "C" void test_uint_least64_t(uint_least64_t x){}
-extern "C" void test_ptr_uint_least64_t(uint_least64_t* x){}
-extern "C" void test_ptr_ptr_uint_least64_t(uint_least64_t** x){}
+extern "C" void test_uint8_t(uint8_t x) {}
+extern "C" void test_ptr_uint8_t(uint8_t* x) {}
+extern "C" void test_ptr_ptr_uint8_t(uint8_t** x) {}
+extern "C" void test_uint16_t(uint16_t x) {}
+extern "C" void test_ptr_uint16_t(uint16_t* x) {}
+extern "C" void test_ptr_ptr_uint16_t(uint16_t** x) {}
+extern "C" void test_uint32_t(uint32_t x) {}
+extern "C" void test_ptr_uint32_t(uint32_t* x) {}
+extern "C" void test_ptr_ptr_uint32_t(uint32_t** x) {}
+extern "C" void test_uint64_t(uint64_t x) {}
+extern "C" void test_ptr_uint64_t(uint64_t* x) {}
+extern "C" void test_ptr_ptr_uint64_t(uint64_t** x) {}
+extern "C" void test_uint_fast8_t(uint_fast8_t x) {}
+extern "C" void test_ptr_uint_fast8_t(uint_fast8_t* x) {}
+extern "C" void test_ptr_ptr_uint_fast8_t(uint_fast8_t** x) {}
+extern "C" void test_uint_fast16_t(uint_fast16_t x) {}
+extern "C" void test_ptr_uint_fast16_t(uint_fast16_t* x) {}
+extern "C" void test_ptr_ptr_uint_fast16_t(uint_fast16_t** x) {}
+extern "C" void test_uint_fast32_t(uint_fast32_t x) {}
+extern "C" void test_ptr_uint_fast32_t(uint_fast32_t* x) {}
+extern "C" void test_ptr_ptr_uint_fast32_t(uint_fast32_t** x) {}
+extern "C" void test_uint_fast64_t(uint_fast64_t x) {}
+extern "C" void test_ptr_uint_fast64_t(uint_fast64_t* x) {}
+extern "C" void test_ptr_ptr_uint_fast64_t(uint_fast64_t** x) {}
+extern "C" void test_uint_least8_t(uint_least8_t x) {}
+extern "C" void test_ptr_uint_least8_t(uint_least8_t* x) {}
+extern "C" void test_ptr_ptr_uint_least8_t(uint_least8_t** x) {}
+extern "C" void test_uint_least16_t(uint_least16_t x) {}
+extern "C" void test_ptr_uint_least16_t(uint_least16_t* x) {}
+extern "C" void test_ptr_ptr_uint_least16_t(uint_least16_t** x) {}
+extern "C" void test_uint_least32_t(uint_least32_t x) {}
+extern "C" void test_ptr_uint_least32_t(uint_least32_t* x) {}
+extern "C" void test_ptr_ptr_uint_least32_t(uint_least32_t** x) {}
+extern "C" void test_uint_least64_t(uint_least64_t x) {}
+extern "C" void test_ptr_uint_least64_t(uint_least64_t* x) {}
+extern "C" void test_ptr_ptr_uint_least64_t(uint_least64_t** x) {}
 
 // Register Allocation - Null Type
-extern "C" void test_void(){}
+extern "C" void test_void() {}

--- a/test/source/libs/gen_allocation.py
+++ b/test/source/libs/gen_allocation.py
@@ -143,7 +143,6 @@ def make_tests(file, category, types):
         for p in [['*', 'ptr_', 1], ['**','ptr_ptr_', 2]]:
             file.write(subcase.format(t['name']+p[0], p[1]+name, '%rdi'))
             file.write('    CHECK(parameters[0].class_name() == "Pointer");\n')
-            file.write('    CHECK(parameters[0].pointer_indirections() == {0});\n'.format(p[2]))
             file.write('  }')
     
     file.write("\n}\n")


### PR DESCRIPTION
This is a tiny change to have indirections be a variable that is specific to a pointer type, which we can do now that we have polymorphic types! We are going to need to modify our testing strategy to generation json to validate now that all the parameters are going to output slightly different content.

Signed-off-by: vsoch <vsoch@users.noreply.github.com>