### PR TITLE
Start of work to check for pointer in makeJson.

### DIFF
--- a/source/parser/x86_64/types.hpp
+++ b/source/parser/x86_64/types.hpp
@@ -235,17 +235,12 @@ namespace smeagle::x86_64::types {
                                    "",         param_type->getSize()};
 
       if (ptr_cnt > 0) {
-        auto ptr = types::pointer_t{param_name,
-                                    underlying_type->getName(),
-                                    "",
-                                    "",
-                                    "",
-                                    param_type->getSize(),
-                                    ptr_cnt,
-                                    std::move(param)};
+        auto ptr = types::pointer_t<decltype(param)>{
+            param_name, underlying_type->getName(), "Pointer", "",
+            "",         param_type->getSize(),      ptr_cnt,   std::move(param)};
         ptr.toJson(out, indent);
       } else {
-        param.toJson(out, indent);   
+        param.toJson(out, indent);
       }
 
       // Structure Type
@@ -253,34 +248,77 @@ namespace smeagle::x86_64::types {
       using dyn_t = std::decay_t<decltype(*t)>;
       auto param = types::struct_t<dyn_t>{param_name, param_type->getName(), "Struct", direction,
                                           "",         param_type->getSize(), t};
-      param.toJson(out, indent, types::struct_t<dyn_t>::recursive_t{});
+
+      if (ptr_cnt > 0) {
+        auto ptr = types::pointer_t<decltype(param)>{
+            param_name, underlying_type->getName(), "Pointer", "",
+            "",         param_type->getSize(),      ptr_cnt,   std::move(param)};
+
+        ptr.toJson(out, indent);
+      } else {
+        param.toJson(out, indent, types::struct_t<dyn_t>::recursive_t{});
+      }
 
       // Union Type
     } else if (auto *t = underlying_type->getUnionType()) {
       using dyn_t = std::decay_t<decltype(*t)>;
       auto param = types::union_t<dyn_t>{param_name, param_type->getName(), "Union", direction,
                                          "",         param_type->getSize(), t};
-      param.toJson(out, indent);
+      if (ptr_cnt > 0) {
+        auto ptr = types::pointer_t<decltype(param)>{
+            param_name, underlying_type->getName(), "Pointer", "",
+            "",         param_type->getSize(),      ptr_cnt,   std::move(param)};
+
+        ptr.toJson(out, indent);
+      } else {
+        param.toJson(out, indent);
+      }
 
       // Array Type
     } else if (auto *t = underlying_type->getArrayType()) {
       using dyn_t = std::decay_t<decltype(*t)>;
       auto param = types::array_t<dyn_t>{param_name, param_type->getName(), "Array", direction,
                                          "",         param_type->getSize()};
-      param.toJson(out, indent);
+
+      if (ptr_cnt > 0) {
+        auto ptr = types::pointer_t<decltype(param)>{
+            param_name, underlying_type->getName(), "Pointer", "",
+            "",         param_type->getSize(),      ptr_cnt,   std::move(param)};
+
+        ptr.toJson(out, indent);
+      } else {
+        param.toJson(out, indent);
+      }
 
       // Enum Type
     } else if (auto *t = underlying_type->getEnumType()) {
       using dyn_t = std::decay_t<decltype(*t)>;
       auto param = types::enum_t<dyn_t>{param_name, param_type->getName(), "Enum", direction,
                                         "",         param_type->getSize(), t};
-      param.toJson(out, indent);
+
+      if (ptr_cnt > 0) {
+        auto ptr = types::pointer_t<decltype(param)>{
+            param_name, underlying_type->getName(), "Pointer", "",
+            "",         param_type->getSize(),      ptr_cnt,   std::move(param)};
+
+        ptr.toJson(out, indent);
+      } else {
+        param.toJson(out, indent);
+      }
 
       // Function Type
     } else if (auto *t = underlying_type->getFunctionType()) {
       auto param = types::function_t{param_name, param_type->getName(), "Function", direction,
                                      "",         param_type->getSize()};
-      param.toJson(out, indent);
+      if (ptr_cnt > 0) {
+        auto ptr = types::pointer_t<decltype(param)>{
+            param_name, underlying_type->getName(), "Pointer", "",
+            "",         param_type->getSize(),      ptr_cnt,   std::move(param)};
+
+        ptr.toJson(out, indent);
+      } else {
+        param.toJson(out, indent);
+      }
 
     } else {
       throw std::runtime_error{"Unknown type " + param_type->getName()};

--- a/source/parser/x86_64/types.hpp
+++ b/source/parser/x86_64/types.hpp
@@ -118,7 +118,7 @@ namespace smeagle::x86_64::types {
 
     struct recursive_t final {};
 
-    void toJson(std::ostream &out, int indent, recursive_t) { parse(out, indent); }
+    void toJson(std::ostream &out, int indent, recursive_t) const { parse(out, indent); }
 
     void toJson(std::ostream &out, int indent) const {
       seen.clear();

--- a/source/parser/x86_64/types.hpp
+++ b/source/parser/x86_64/types.hpp
@@ -270,9 +270,9 @@ namespace smeagle::x86_64::types {
             param_name, underlying_type->getName(), "Pointer", "",
             "",         param_type->getSize(),      ptr_cnt,   std::move(param)};
 
-        ptr.toJson(out, indent, types::union_t<decltype(param)>::recursive_t{});
+        ptr.toJson(out, indent, types::union_t<dyn_t>::recursive_t{});
       } else {
-        param.toJson(out, indent, types::union_t<decltype(param)>::recursive_t{});
+        param.toJson(out, indent, types::union_t<dyn_t>::recursive_t{});
       }
 
       // Array Type

--- a/source/parser/x86_64/types.hpp
+++ b/source/parser/x86_64/types.hpp
@@ -8,8 +8,16 @@
 #include <utility>
 #include <vector>
 
+#include "classifiers.hpp"
+
+// TODO need to add pointer logic to makeJson
+// That looks good to me. Let's merge! I would say the next item to work on is handling pointers in
+// makeJson. For example, if you have a struct with a member that is a pointer to another
+// struct/union, we don't capture the pointer indirection in the underlying_type in the JSON.
+
 namespace smeagle::x86_64::types {
 
+  namespace st = Dyninst::SymtabAPI;
   namespace detail {
     /*
      *  This class has an intentially weird layout. We leave the members public to make it an
@@ -225,12 +233,33 @@ namespace smeagle::x86_64::types {
   };
 
   // Parse a parameter into a Smeagle parameter
-  void makeJson(st::Type *param_type, std::string param_name, std::ostream &out, int indent) {
+  template <typename class_t, typename base_t, typename param_t, typename... Args>
+  void makeJson(st::Type *param_type, std::string param_name, std::ostream &out, int indent,
+                Args &&... args) {
     auto [underlying_type, ptr_cnt] = unwrap_underlying_type(param_type);
     std::string direction = "";
 
-    // Scalar Type
-    if (auto *t = underlying_type->getScalarType()) {
+    // If we have a pointer, we need to capture the pointer and underlying type
+    if (ptr_cnt > 0) {
+      // On x86, all pointers are the same ABI class
+      auto ptr_class = classify_pointer(ptr_cnt);
+      auto base_class = classify(underlying_type);
+
+      // Allocate space for the pointer (NOT the underlying type)
+      auto ptr_type_name = underlying_type->getName();
+      auto param = smeagle::parameter{
+          types::pointer_t<class_t>{param_name,
+                                    ptr_type_name,
+                                    ptr_class.name,
+                                    "",
+                                    "",
+                                    param_type->getSize(),
+                                    ptr_cnt,
+                                    {"", underlying_type->getName(), base_class.name, "", "",
+                                     underlying_type->getSize(), std::forward<Args>(args)...}}};
+
+      // Scalar Type
+    } else if (auto *t = underlying_type->getScalarType()) {
       auto param = types::scalar_t{param_name, param_type->getName(), "Scalar", direction,
                                    "",         param_type->getSize()};
       param.toJson(out, indent);

--- a/source/parser/x86_64/types.hpp
+++ b/source/parser/x86_64/types.hpp
@@ -213,8 +213,7 @@ namespace smeagle::x86_64::types {
     int pointer_indirections;
     T underlying_type;
 
-    template<typename... Args>
-    void toJson(std::ostream &out, int indent, Args &&... args) const {
+    template <typename... Args> void toJson(std::ostream &out, int indent, Args &&... args) const {
       auto buf = std::string(indent, ' ');
       out << buf << "{\n";
       detail::toJson(*this, out, indent + 2);

--- a/source/parser/x86_64/types.hpp
+++ b/source/parser/x86_64/types.hpp
@@ -213,13 +213,14 @@ namespace smeagle::x86_64::types {
     int pointer_indirections;
     T underlying_type;
 
-    void toJson(std::ostream &out, int indent) const {
+    template<typename... Args>
+    void toJson(std::ostream &out, int indent, Args &&... args) const {
       auto buf = std::string(indent, ' ');
       out << buf << "{\n";
       detail::toJson(*this, out, indent + 2);
       out << ",\n" << buf << "  \"indirections\":\"" << pointer_indirections << "\"";
       out << ",\n" << buf << "  \"underlying_type\": ";
-      underlying_type.toJson(out, indent + 4);
+      underlying_type.toJson(out, indent + 4, std::forward<Args>(args)...);
       out << "}";
     }
   };

--- a/source/parser/x86_64/types.hpp
+++ b/source/parser/x86_64/types.hpp
@@ -255,7 +255,7 @@ namespace smeagle::x86_64::types {
             param_name, underlying_type->getName(), "Pointer", "",
             "",         param_type->getSize(),      ptr_cnt,   std::move(param)};
 
-        ptr.toJson(out, indent);
+        ptr.toJson(out, indent, types::struct_t<dyn_t>::recursive_t{});
       } else {
         param.toJson(out, indent, types::struct_t<dyn_t>::recursive_t{});
       }

--- a/source/parser/x86_64/types.hpp
+++ b/source/parser/x86_64/types.hpp
@@ -270,9 +270,9 @@ namespace smeagle::x86_64::types {
             param_name, underlying_type->getName(), "Pointer", "",
             "",         param_type->getSize(),      ptr_cnt,   std::move(param)};
 
-        ptr.toJson(out, indent);
+        ptr.toJson(out, indent, types::union_t<decltype(param)>::recursive_t{});
       } else {
-        param.toJson(out, indent);
+        param.toJson(out, indent, types::union_t<decltype(param)>::recursive_t{});
       }
 
       // Array Type

--- a/source/parser/x86_64/types.hpp
+++ b/source/parser/x86_64/types.hpp
@@ -67,7 +67,7 @@ namespace smeagle::x86_64::types {
 
     struct recursive_t final {};
 
-    void toJson(std::ostream &out, int indent, recursive_t) { parse(out, indent); }
+    void toJson(std::ostream &out, int indent, recursive_t) const { parse(out, indent); }
     void toJson(std::ostream &out, int indent) const {
       seen.clear();
       parse(out, indent);


### PR DESCRIPTION
So I think I'm close here - I'm trying to use the classify function and there is a hint that it is found, but I'm not referencing it correctly? E.g., I see one of these for each Dyninst type:

```
/code/source/parser/x86_64/classifiers.hpp:84:25: note:   conversion of argument 1 would be ill-formed:
/code/source/parser/x86_64/classifiers.hpp:87:25: note: candidate: smeagle::x86_64::classification smeagle::x86_64::classify(Dyninst::SymtabAPI::typeFunction*) <near match>
   inline classification classify(st::typeFunction *) { return {}; }
                         ^~~~~~~~
```
@hainest when you are around let's discuss! I think I'm probably close and this "ill-formed" business is some niche C++ thing I haven't seen before.

Signed-off-by: vsoch <vsoch@users.noreply.github.com>