### PR TITLE
Start classify array segfault

### DIFF
--- a/source/parser/x86_64/classifiers.hpp
+++ b/source/parser/x86_64/classifiers.hpp
@@ -234,6 +234,7 @@ namespace smeagle::x86_64 {
 
   // Classify a single field
   classification classify(st::Field *f) {
+    // Just classify the type of the field
     return classify_type(f->getType());
   }
 

--- a/source/parser/x86_64/classifiers.hpp
+++ b/source/parser/x86_64/classifiers.hpp
@@ -35,8 +35,8 @@ namespace smeagle::x86_64 {
   }
 
   // classify a base underlying type
-  inline classification classify_type(st::Type fieldType) {
-    auto [underlying_type, ptr_cnt] = unwrap_underlying_type(&fieldType);
+  inline classification classify_type(st::Type *fieldType) {
+    auto [underlying_type, ptr_cnt] = unwrap_underlying_type(fieldType);
 
     if (ptr_cnt > 0) {
       return classify_pointer(ptr_cnt);
@@ -224,7 +224,7 @@ namespace smeagle::x86_64 {
 
     // Just classify the base type
     const auto baseType = t->getBaseType();
-    return classify_type(*baseType);
+    return classify_type(baseType);
   }
 
   inline classification classify(st::typeEnum *t) {
@@ -236,7 +236,7 @@ namespace smeagle::x86_64 {
   // Classify a single field
   classification classify(st::Field *f) {
     auto *fieldType = f->getType();
-    return classify_type(*fieldType);
+    return classify_type(fieldType);
   }
 
 }  // namespace smeagle::x86_64

--- a/source/parser/x86_64/classifiers.hpp
+++ b/source/parser/x86_64/classifiers.hpp
@@ -223,8 +223,7 @@ namespace smeagle::x86_64 {
     }
 
     // Just classify the base type
-    const auto baseType = t->getBaseType();
-    return classify_type(baseType);
+    return classify_type(t->getBaseType());
   }
 
   inline classification classify(st::typeEnum *t) {
@@ -235,8 +234,7 @@ namespace smeagle::x86_64 {
 
   // Classify a single field
   classification classify(st::Field *f) {
-    auto *fieldType = f->getType();
-    return classify_type(fieldType);
+    return classify_type(f->getType());
   }
 
 }  // namespace smeagle::x86_64

--- a/source/parser/x86_64/classifiers.hpp
+++ b/source/parser/x86_64/classifiers.hpp
@@ -35,7 +35,13 @@ namespace smeagle::x86_64 {
   }
 
   // classify a base underlying type
-  inline classification classify_type(st::Type *underlying_type) {
+  inline classification classify_type(st::Type fieldType) {
+    auto [underlying_type, ptr_cnt] = unwrap_underlying_type(&fieldType);
+
+    if (ptr_cnt > 0) {
+      return classify_pointer(ptr_cnt);
+    }
+
     if (auto *t = underlying_type->getScalarType()) {
       return classify(t);
     } else if (auto *t = underlying_type->getStructType()) {
@@ -218,12 +224,7 @@ namespace smeagle::x86_64 {
 
     // Just classify the base type
     const auto baseType = t->getBaseType();
-    auto [underlying_type, ptr_cnt] = unwrap_underlying_type(baseType);
-
-    if (ptr_cnt > 0) {
-      return classify_pointer(ptr_cnt);
-    }
-    return classify_type(underlying_type);
+    return classify_type(*baseType);
   }
 
   inline classification classify(st::typeEnum *t) {
@@ -235,12 +236,7 @@ namespace smeagle::x86_64 {
   // Classify a single field
   classification classify(st::Field *f) {
     auto *fieldType = f->getType();
-    auto [underlying_type, ptr_cnt] = unwrap_underlying_type(fieldType);
-
-    if (ptr_cnt > 0) {
-      return classify_pointer(ptr_cnt);
-    }
-    return classify_type(underlying_type);
+    return classify_type(*fieldType);
   }
 
 }  // namespace smeagle::x86_64


### PR DESCRIPTION
This is the same as #81 but with a consolidation change requested by @hainest. But I don't think we should do it because it segfaults (unless we can fix the error that causes that, which I'm not sure about). @hainest can you take a look?