### PR TITLE
Ensuring anon struct/union uses type for name

### DIFF
--- a/source/parser/x86_64/types.hpp
+++ b/source/parser/x86_64/types.hpp
@@ -246,6 +246,11 @@ namespace smeagle::x86_64::types {
       // Structure Type
     } else if (auto *t = underlying_type->getStructType()) {
       using dyn_t = std::decay_t<decltype(*t)>;
+
+      // If it's anonymous, use the type
+      if (param_name.find("anonymous") != std::string::npos) {
+        param_name = param_type->getName();
+      }
       auto param = types::struct_t<dyn_t>{param_name, param_type->getName(), "Struct", direction,
                                           "",         param_type->getSize(), t};
 
@@ -262,6 +267,12 @@ namespace smeagle::x86_64::types {
       // Union Type
     } else if (auto *t = underlying_type->getUnionType()) {
       using dyn_t = std::decay_t<decltype(*t)>;
+
+      // If it's anonymous, use the type
+      if (param_name.find("anonymous") != std::string::npos) {
+        param_name = param_type->getName();
+      }
+
       auto param = types::union_t<dyn_t>{param_name, param_type->getName(), "Union", direction,
                                          "",         param_type->getSize(), t};
       if (ptr_cnt > 0) {

--- a/source/parser/x86_64/types.hpp
+++ b/source/parser/x86_64/types.hpp
@@ -248,7 +248,7 @@ namespace smeagle::x86_64::types {
       using dyn_t = std::decay_t<decltype(*t)>;
 
       // If it's anonymous, use the type
-      if (param_name.find("anonymous") != std::string::npos) {
+      if (param_name.find("anonymous struct") != std::string::npos) {
         param_name = param_type->getName();
       }
       auto param = types::struct_t<dyn_t>{param_name, param_type->getName(), "Struct", direction,
@@ -269,7 +269,7 @@ namespace smeagle::x86_64::types {
       using dyn_t = std::decay_t<decltype(*t)>;
 
       // If it's anonymous, use the type
-      if (param_name.find("anonymous") != std::string::npos) {
+      if (param_name.find("anonymous union") != std::string::npos) {
         param_name = param_type->getName();
       }
 

--- a/source/parser/x86_64/types.hpp
+++ b/source/parser/x86_64/types.hpp
@@ -247,10 +247,6 @@ namespace smeagle::x86_64::types {
     } else if (auto *t = underlying_type->getStructType()) {
       using dyn_t = std::decay_t<decltype(*t)>;
 
-      // If it's anonymous, use the type
-      if (param_name.find("anonymous struct") != std::string::npos) {
-        param_name = param_type->getName();
-      }
       auto param = types::struct_t<dyn_t>{param_name, param_type->getName(), "Struct", direction,
                                           "",         param_type->getSize(), t};
 
@@ -267,11 +263,6 @@ namespace smeagle::x86_64::types {
       // Union Type
     } else if (auto *t = underlying_type->getUnionType()) {
       using dyn_t = std::decay_t<decltype(*t)>;
-
-      // If it's anonymous, use the type
-      if (param_name.find("anonymous union") != std::string::npos) {
-        param_name = param_type->getName();
-      }
 
       auto param = types::union_t<dyn_t>{param_name, param_type->getName(), "Union", direction,
                                          "",         param_type->getSize(), t};

--- a/source/parser/x86_64/x86_64.cpp
+++ b/source/parser/x86_64/x86_64.cpp
@@ -46,12 +46,19 @@ namespace smeagle::x86_64 {
     return "unknown";
   }
 
+  // Determine if a type is anonymous
+  bool is_anonymous(st::Type *t) {
+    return t->getName().find("anonymous struct") != std::string::npos
+           || t->getName().find("anonymous class") != std::string::npos
+           || t->getName().find("anonymous union") != std::string::npos;
+  }
+
   template <typename class_t, typename base_t, typename param_t, typename... Args>
   smeagle::parameter classify(std::string const &param_name, base_t *base_type, param_t *param_type,
                               RegisterAllocator &allocator, int ptr_cnt, Args &&... args) {
-    auto base_type_name = base_type->getName();
+    // If it's anonymous, we use the base type name
+    auto base_type_name = is_anonymous(base_type) ? param_type->getName() : base_type->getName();
     auto direction = getDirectionalityFromType(param_type);
-
     auto base_class = classify(base_type);
 
     if (ptr_cnt > 0) {


### PR DESCRIPTION
currently we output a string like "anonymous <type> at-super-long-unreadable-thing" and instead we should just have the name be the type if it is anonymous. There is no good function to derive this for dyninst so we have to check the string.

Signed-off-by: vsoch <vsoch@users.noreply.github.com>